### PR TITLE
Fixed invalid PresentationML parsing of recently added elements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+### :white_check_mark: Checklist 
+- [ ] Unit tests and Javadoc
+- [ ] Generated PresentationML is valid
+> :warning: For this point, please make sure that you have also added a complete example in the 
+> `/examples` resources folder. This way the `Mml2Pml2Pml.java` test will ensure that the generated PresentationML is 
+> an actual MessageML valid one. 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
         <mockito.version>4.0.0</mockito.version>
         <slf4j.version>1.7.31</slf4j.version>
         <jmh.version>1.33</jmh.version>
+        <xmlunit.version>2.8.3</xmlunit.version>
+        <lombok.version>1.18.22</lombok.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.jar.version>3.1.2</maven.jar.version>
@@ -114,7 +116,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -199,9 +201,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.7</version>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>${xmlunit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.22</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>${json.schema.validator.version}</version>
@@ -190,6 +196,12 @@
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -720,6 +720,14 @@ public class MessageMLParser {
     }
   }
 
+  /**
+   * Method that allows to automatically transform any PresentationML <code>div</code> to its actual MessageML
+   * corresponding element.
+   * <p>For instance:
+   * <pre>&#60;div class="ui-action"&#62;</pre>
+   * will be transformed to:
+   * <pre>&#60;ui-action&#62;</pre>
+   */
   private Element createElementFromDiv(org.w3c.dom.Element element, Element parent) throws InvalidInputException {
     if (element.hasAttribute(SplittableElement.PRESENTATIONML_DIV_FLAG)) {
       // Special div created by a splittable element, it is not converted in MessageML or in PresentationML tree object
@@ -765,9 +773,6 @@ public class MessageMLParser {
     } else if (containsAttribute(elementClass, TimezonePicker.PRESENTATIONML_CLASS)) {
       removeAttribute(element, CLASS_ATTR, TimezonePicker.PRESENTATIONML_CLASS);
       return new TimezonePicker(parent, FormatEnum.PRESENTATIONML);
-    } else if (containsAttribute(elementClass, Dialog.PRESENTATIONML_CLASS)) {
-      removeAttribute(element, CLASS_ATTR, Dialog.PRESENTATIONML_CLASS);
-      return new Dialog(parent, FormatEnum.PRESENTATIONML);
     } else {
       return new Div(parent);
     }

--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -759,6 +759,15 @@ public class MessageMLParser {
     } else if (containsAttribute(elementClass, Radio.PRESENTATIONML_DIV_CLASS)) {
       removeAttribute(element, CLASS_ATTR, Radio.PRESENTATIONML_DIV_CLASS);
       return new Radio(parent, FormatEnum.PRESENTATIONML);
+    } else if (containsAttribute(elementClass, UIAction.PRESENTATIONML_CLASS)) {
+      removeAttribute(element, CLASS_ATTR, UIAction.PRESENTATIONML_CLASS);
+      return new UIAction(parent, FormatEnum.PRESENTATIONML);
+    } else if (containsAttribute(elementClass, TimezonePicker.PRESENTATIONML_CLASS)) {
+      removeAttribute(element, CLASS_ATTR, TimezonePicker.PRESENTATIONML_CLASS);
+      return new TimezonePicker(parent, FormatEnum.PRESENTATIONML);
+    } else if (containsAttribute(elementClass, Dialog.PRESENTATIONML_CLASS)) {
+      removeAttribute(element, CLASS_ATTR, Dialog.PRESENTATIONML_CLASS);
+      return new Dialog(parent, FormatEnum.PRESENTATIONML);
     } else {
       return new Div(parent);
     }

--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -715,8 +715,7 @@ public class MessageMLParser {
     } else if (containsAttribute(elementType, TimePicker.PRESENTATIONML_INPUT_TYPE)) {
       return new TimePicker(parent, FormatEnum.PRESENTATIONML);
     } else {
-      throw new InvalidInputException(
-          String.format("The input type \"%s\" is not allowed on PresentationML", elementType));
+      throw new InvalidInputException("The input type \"%s\" is not allowed on PresentationML", elementType);
     }
   }
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Card.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Card.java
@@ -37,26 +37,25 @@ import java.util.Map;
 public class Card extends Element {
 
   public static final String MESSAGEML_TAG = "card";
+  public static final String PRESENTATIONML_ICON_ATTR = "data-icon-src";
+  public static final String PRESENTATIONML_ACCENT_ATTR = "data-accent-color";
   public static final String PRESENTATIONML_CLASS = "card";
   private static final String PRESENTATIONML_TAG = "div";
   private static final String ATTR_ICON = "iconSrc";
   private static final String ATTR_ACCENT = "accent";
-  private static final String PRESENTATIONML_ICON = "data-icon-src";
-  private static final String PRESENTATIONML_ACCENT = "data-accent-color";
 
   public Card(Element parent, FormatEnum format) {
     super(parent, MESSAGEML_TAG, format);
   }
 
   @Override
-  protected void buildAttribute(MessageMLParser parser,
-      Node item) throws InvalidInputException {
+  protected void buildAttribute(MessageMLParser parser, Node item) throws InvalidInputException {
     switch (item.getNodeName()) {
-      case PRESENTATIONML_ICON:
+      case PRESENTATIONML_ICON_ATTR:
       case ATTR_ICON:
         setAttribute(ATTR_ICON, getStringAttribute(item));
         break;
-      case PRESENTATIONML_ACCENT:
+      case PRESENTATIONML_ACCENT_ATTR:
       case ATTR_ACCENT:
         setAttribute(ATTR_ACCENT, getStringAttribute(item));
         break;
@@ -66,8 +65,7 @@ public class Card extends Element {
   }
 
   @Override
-  public void asPresentationML(XmlPrintStream out,
-      MessageMLContext context) {
+  public void asPresentationML(XmlPrintStream out, MessageMLContext context) {
     Map<String, String> presentationAttrs = new LinkedHashMap<>();
     if (getAttribute(CLASS_ATTR) != null) {
       presentationAttrs.put(CLASS_ATTR, String.format("%s %s", PRESENTATIONML_CLASS, getAttribute(CLASS_ATTR)));
@@ -75,10 +73,10 @@ public class Card extends Element {
       presentationAttrs.put(CLASS_ATTR, PRESENTATIONML_CLASS);
     }
     if (getAttribute(ATTR_ICON) != null) {
-      presentationAttrs.put(PRESENTATIONML_ICON, getAttribute(ATTR_ICON));
+      presentationAttrs.put(PRESENTATIONML_ICON_ATTR, getAttribute(ATTR_ICON));
     }
     if (getAttribute(ATTR_ACCENT) != null) {
-      presentationAttrs.put(PRESENTATIONML_ACCENT, getAttribute(ATTR_ACCENT));
+      presentationAttrs.put(PRESENTATIONML_ACCENT_ATTR, getAttribute(ATTR_ACCENT));
     }
 
     out.openElement(PRESENTATIONML_TAG, presentationAttrs);

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
@@ -115,15 +115,12 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
       assertAttributeMaxLength(FORMAT_ATTR, DEFAULT_MAX_LENGTH);
       String format = getAttribute(FORMAT_ATTR);
       if(!format.matches(DATE_FORMAT_ALLOWED)){
-        throw new InvalidInputException(
-            String.format("Attribute \"%s\" contains an unsupported date format, only 'M', 'd' and 'y' are supported with a space or '.','-','/',':' as separator", FORMAT_ATTR)
-        );
+        throw new InvalidInputException("Attribute \"%s\" contains an unsupported date format, only 'M', 'd' and 'y' are supported with a space or '.','-','/',':' as separator", FORMAT_ATTR);
       }
       try {
         DateTimeFormatter.ofPattern(getAttribute(FORMAT_ATTR));
       } catch (IllegalArgumentException i) {
-        throw new InvalidInputException(
-            String.format("Attribute \"%s\" contains an invalid date format", FORMAT_ATTR));
+        throw new InvalidInputException("Attribute \"%s\" contains an invalid date format", FORMAT_ATTR);
       }
     }
     assertAttributeMaxLength(TITLE, DEFAULT_MAX_LENGTH);
@@ -142,66 +139,6 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
       out.closeElement();
     } else {
       innerAsPresentationML(out, presentationAttrs);
-    }
-  }
-
-  @Override
-  public void updateBiContext(BiContext context) {
-    Map<String, Object> attributesMapBi = new HashMap<>();
-
-    this.putOneIfPresent(attributesMapBi, BiFields.TITLE.getValue(), TITLE);
-    this.putOneIfPresent(attributesMapBi, BiFields.PLACEHOLDER.getValue(), PLACEHOLDER_ATTR);
-    this.putOneIfPresent(attributesMapBi, BiFields.LABEL.getValue(), LABEL);
-    this.putOneIfPresent(attributesMapBi, BiFields.REQUIRED.getValue(), REQUIRED_ATTR);
-    this.computeAndPutDefault(attributesMapBi);
-    this.computeAndPutValidationProperties(attributesMapBi);
-
-    context.addItem(new BiItem(BiFields.DATE_SELECTOR.getValue(), attributesMapBi));
-  }
-
-  @Override
-  public org.commonmark.node.Node asMarkdown() {
-    return new DatePickerNode(getAttribute(LABEL), getAttribute(TITLE), getAttribute(PLACEHOLDER_ATTR));
-  }
-
-  private void computeAndPutDefault(Map<String, Object> attributesMapBi) {
-    boolean hasDefaultValue = getAttribute(VALUE_ATTR) != null;
-    if (hasDefaultValue) {
-      attributesMapBi.put(BiFields.DEFAULT.getValue(), 1);
-    }
-  }
-
-  private void computeAndPutValidationProperties(Map<String, Object> attributesMapBi) {
-    boolean validationMin = getAttribute(MIN_ATTR) != null;
-    boolean validationMax = getAttribute(MAX_ATTR) != null;
-    boolean validationPattern = getAttribute(FORMAT_ATTR) != null;
-    boolean validationOptions = getAttribute(DISABLED_DATE_ATTR) != null;
-    boolean highlightedOptions = getAttribute(HIGHLIGHTED_DATE_ATTR) != null;
-    boolean hasValidation =
-        validationMin || validationMax || validationPattern || validationOptions;
-
-    if (validationMin) {
-      attributesMapBi.put(BiFields.VALIDATION_MIN.getValue(), 1);
-    }
-
-    if (validationMax) {
-      attributesMapBi.put(BiFields.VALIDATION_MAX.getValue(), 1);
-    }
-
-    if (validationPattern) {
-      attributesMapBi.put(BiFields.VALIDATION_PATTERN.getValue(), 1);
-    }
-
-    if (validationOptions) {
-      attributesMapBi.put(BiFields.VALIDATION_OPTIONS.getValue(), 1);
-    }
-
-    if (highlightedOptions) {
-      attributesMapBi.put(BiFields.HIGHLIGHTED_OPTIONS.getValue(), 1);
-    }
-
-    if (hasValidation) {
-      attributesMapBi.put(BiFields.VALIDATION.getValue(), 1);
     }
   }
 
@@ -293,6 +230,65 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
             String.format("Error parsing json in attribute \"%s\": %s", attributeName,
                 e.getMessage()), e);
       }
+    }
+  }
+
+  @Override
+  public org.commonmark.node.Node asMarkdown() {
+    return new DatePickerNode(getAttribute(LABEL), getAttribute(TITLE), getAttribute(PLACEHOLDER_ATTR));
+  }
+
+  @Override
+  public void updateBiContext(BiContext context) {
+    Map<String, Object> attributesMapBi = new HashMap<>();
+
+    this.putOneIfPresent(attributesMapBi, BiFields.TITLE.getValue(), TITLE);
+    this.putOneIfPresent(attributesMapBi, BiFields.PLACEHOLDER.getValue(), PLACEHOLDER_ATTR);
+    this.putOneIfPresent(attributesMapBi, BiFields.LABEL.getValue(), LABEL);
+    this.putOneIfPresent(attributesMapBi, BiFields.REQUIRED.getValue(), REQUIRED_ATTR);
+    this.computeAndPutDefault(attributesMapBi);
+    this.computeAndPutValidationProperties(attributesMapBi);
+
+    context.addItem(new BiItem(BiFields.DATE_SELECTOR.getValue(), attributesMapBi));
+  }
+
+  private void computeAndPutDefault(Map<String, Object> attributesMapBi) {
+    boolean hasDefaultValue = getAttribute(VALUE_ATTR) != null;
+    if (hasDefaultValue) {
+      attributesMapBi.put(BiFields.DEFAULT.getValue(), 1);
+    }
+  }
+
+  private void computeAndPutValidationProperties(Map<String, Object> attributesMapBi) {
+    boolean validationMin = getAttribute(MIN_ATTR) != null;
+    boolean validationMax = getAttribute(MAX_ATTR) != null;
+    boolean validationPattern = getAttribute(FORMAT_ATTR) != null;
+    boolean validationOptions = getAttribute(DISABLED_DATE_ATTR) != null;
+    boolean highlightedOptions = getAttribute(HIGHLIGHTED_DATE_ATTR) != null;
+    boolean hasValidation = validationMin || validationMax || validationPattern || validationOptions;
+
+    if (validationMin) {
+      attributesMapBi.put(BiFields.VALIDATION_MIN.getValue(), 1);
+    }
+
+    if (validationMax) {
+      attributesMapBi.put(BiFields.VALIDATION_MAX.getValue(), 1);
+    }
+
+    if (validationPattern) {
+      attributesMapBi.put(BiFields.VALIDATION_PATTERN.getValue(), 1);
+    }
+
+    if (validationOptions) {
+      attributesMapBi.put(BiFields.VALIDATION_OPTIONS.getValue(), 1);
+    }
+
+    if (highlightedOptions) {
+      attributesMapBi.put(BiFields.HIGHLIGHTED_OPTIONS.getValue(), 1);
+    }
+
+    if (hasValidation) {
+      attributesMapBi.put(BiFields.VALIDATION.getValue(), 1);
     }
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
@@ -74,6 +74,7 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
         }
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
+      case TYPE_ATTR:
       case ID_ATTR:
       case DISABLED_DATE_PRESENTATION_ATTR:
       case HIGHLIGHTED_DATE_PRESENTATION_ATTR:

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
@@ -42,9 +42,9 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
   private static final int DEFAULT_MAX_LENGTH = 64;
 
   // PresentationML specific attributes
-  private static final String DISABLED_DATE_PRESENTATION_ATTR = "data-disabled-date";
-  private static final String HIGHLIGHTED_DATE_PRESENTATION_ATTR = "data-highlighted-date";
-  private static final String FORMAT_PRESENTATION_ATTR = "data-format";
+  private static final String PRESENTATIONML_DISABLED_DATE_ATTR = "data-disabled-date";
+  private static final String PRESENTATIONML_HIGHLIGHTED_DATE_ATTR = "data-highlighted-date";
+  private static final String PRESENTATIONML_FORMAT_ATTR = "data-format";
 
   private static final String DATE_FORMAT_ALLOWED = "^[0-9Mdy\\/. -:]+$";
 
@@ -53,8 +53,7 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
   }
 
   @Override
-  protected void buildAttribute(MessageMLParser parser,
-      Node item) throws InvalidInputException {
+  protected void buildAttribute(MessageMLParser parser, Node item) throws InvalidInputException {
     switch (item.getNodeName()) {
       case NAME_ATTR:
       case VALUE_ATTR:
@@ -76,13 +75,14 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
         break;
       case TYPE_ATTR:
       case ID_ATTR:
-      case DISABLED_DATE_PRESENTATION_ATTR:
-      case HIGHLIGHTED_DATE_PRESENTATION_ATTR:
-      case FORMAT_PRESENTATION_ATTR:
+      case PRESENTATIONML_DISABLED_DATE_ATTR:
+      case PRESENTATIONML_HIGHLIGHTED_DATE_ATTR:
+      case PRESENTATIONML_FORMAT_ATTR:
         if (this.format != FormatEnum.PRESENTATIONML) {
           throwInvalidInputException(item);
         }
         fillAttributes(parser, item);
+        setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       default:
         throwInvalidInputException(item);
@@ -131,8 +131,7 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
   }
 
   @Override
-  public void asPresentationML(XmlPrintStream out,
-      MessageMLContext context) {
+  public void asPresentationML(XmlPrintStream out, MessageMLContext context) {
     Map<String, Object> presentationAttrs = buildDataPickerInputAttributes();
     if (isSplittable()) {
       // open div + adding splittable elements
@@ -229,29 +228,35 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
     if (getAttribute(MAX_ATTR) != null) {
       presentationAttrs.put(MAX_ATTR, getAttribute(MAX_ATTR));
     }
-    if (getAttribute(DISABLED_DATE_ATTR) != null) {
-      presentationAttrs.put(DISABLED_DATE_PRESENTATION_ATTR,
-          convertJsonDateToPresentationML(DISABLED_DATE_ATTR));
-    }
-    if (getAttribute(HIGHLIGHTED_DATE_ATTR) != null) {
-      presentationAttrs.put(HIGHLIGHTED_DATE_PRESENTATION_ATTR,
-          convertJsonDateToPresentationML(HIGHLIGHTED_DATE_ATTR));
-    }
     if (getAttribute(REQUIRED_ATTR) != null) {
       presentationAttrs.put(REQUIRED_ATTR, getAttribute(REQUIRED_ATTR));
     }
-    if (getAttribute(FORMAT_ATTR) != null) {
-      presentationAttrs.put(FORMAT_PRESENTATION_ATTR, getAttribute(FORMAT_ATTR));
+    if (getAttribute(DISABLED_DATE_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_DISABLED_DATE_ATTR, convertJsonDateToPresentationML(DISABLED_DATE_ATTR));
     }
+    if (getAttribute(HIGHLIGHTED_DATE_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_HIGHLIGHTED_DATE_ATTR, convertJsonDateToPresentationML(HIGHLIGHTED_DATE_ATTR));
+    }
+    if (getAttribute(FORMAT_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_FORMAT_ATTR, getAttribute(FORMAT_ATTR));
+    }
+    // PresentationML compatibility
+    if (getAttribute(PRESENTATIONML_DISABLED_DATE_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_DISABLED_DATE_ATTR, getAttribute(PRESENTATIONML_DISABLED_DATE_ATTR));
+    }
+    if (getAttribute(PRESENTATIONML_HIGHLIGHTED_DATE_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_HIGHLIGHTED_DATE_ATTR, getAttribute(PRESENTATIONML_HIGHLIGHTED_DATE_ATTR));
+    }
+    if (getAttribute(PRESENTATIONML_FORMAT_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_FORMAT_ATTR, getAttribute(PRESENTATIONML_FORMAT_ATTR));
+    }
+
     return presentationAttrs;
   }
 
   /**
    * The Json for PresentationML is different from MessageML It needs to be rewritten, by adding the
    * type attribute, based on the content
-   *
-   * @param attributeName
-   * @return
    */
   private XMLAttribute convertJsonDateToPresentationML(String attributeName) {
     try {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
@@ -1,5 +1,8 @@
 package org.symphonyoss.symphony.messageml.elements;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
 import org.symphonyoss.symphony.messageml.bi.BiContext;
@@ -10,8 +13,6 @@ import org.symphonyoss.symphony.messageml.util.ShortID;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 import org.w3c.dom.Node;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,14 +38,16 @@ public class Dialog extends Element {
 
   public static final String STATE_ATTR = "state";
   public static final String CLOSE_STATE = "close";
-  public static final List<String> ALLOWED_STATE_VALUES = Arrays.asList("open", CLOSE_STATE);
+  public static final List<String> ALLOWED_STATE_VALUES = asList("open", CLOSE_STATE);
 
   public static final String WIDTH_ATTR = "width";
   public static final String MEDIUM_WIDTH = "medium";
-  public static final List<String> ALLOWED_WIDTH_VALUES = Arrays.asList("small", MEDIUM_WIDTH, "large", "full-width");
+  public static final List<String> ALLOWED_WIDTH_VALUES = asList("small", MEDIUM_WIDTH, "large", "full-width");
 
   private static final String DATA_ATTRIBUTE_PREFIX = "data-";
-  private static final String OPEN_ATTRIBUTE = "open";
+  private static final String OPEN_ATTR = "open";
+
+  public static final String PRESENTATIONML_CLASS = MESSAGEML_TAG;
 
   private static final ShortID SHORT_ID = new ShortID();
 
@@ -65,6 +68,10 @@ public class Dialog extends Element {
       case ID_ATTR:
       case WIDTH_ATTR:
       case STATE_ATTR:
+      case OPEN_ATTR:
+      case DATA_ATTRIBUTE_PREFIX + STATE_ATTR:
+      case DATA_ATTRIBUTE_PREFIX + WIDTH_ATTR:
+      case DATA_ATTRIBUTE_PREFIX + OPEN_ATTR:
         setAttribute(item.getNodeName(), item.getNodeValue());
         break;
       default:
@@ -124,26 +131,31 @@ public class Dialog extends Element {
   private void validateChildrenTypes() throws InvalidInputException {
     long formsCount = getChildren().stream().filter(element -> element instanceof Form).count();
     if (formsCount == 1) {
-      assertContentModel(Collections.singleton(Form.class),
+      assertContentModel(singleton(Form.class),
           "A \"dialog\" element can't contain a \"form\" element and any other element.");
     } else if (formsCount > 1) {
       throw new InvalidInputException("A \"dialog\" element can contain only one \"form\" element");
     } else {
-      validateChildren(this);
-      assertContentModel(Arrays.asList(DialogChild.Footer.class, DialogChild.Title.class, DialogChild.Body.class));
+      if (this.format == FormatEnum.MESSAGEML) {
+        assertContainsAlwaysChildOfType(singleton(DialogChild.Title.class));
+        assertContainsAlwaysChildOfType(singleton(DialogChild.Body.class));
+        assertContentModel(asList(DialogChild.Footer.class, DialogChild.Title.class, DialogChild.Body.class));
+      } else {
+        assertContainsAlwaysChildMatching(
+            e -> e.isPresentationMLElement("dialog-title") || e.isPresentationMLElement("dialog-body"),
+            "The \"dialog\" element must have at least one child that is any of the following elements: [title,body]."
+        );
+        assertContentModel(
+            e -> e.isPresentationMLElement("dialog-title") || e.isPresentationMLElement("dialog-body") || e.isPresentationMLElement("dialog-footer"),
+            child -> "Element \"" + child.getMessageMLTag() + "\" is not allowed in \"" + this.getMessageMLTag() + "\"");
+      }
     }
-  }
-
-
-  private void validateChildren(Element rootElement) throws InvalidInputException {
-    rootElement.assertContainsAlwaysChildOfType(Collections.singleton(DialogChild.Title.class));
-    rootElement.assertContainsAlwaysChildOfType(Collections.singleton(DialogChild.Body.class));
   }
 
   private Map<String, String> getPresentationMLAttributes() {
     Map<String, String> pmlAttributes = new HashMap<>();
 
-    pmlAttributes.put(OPEN_ATTRIBUTE, "");
+    pmlAttributes.put(OPEN_ATTR, "");
     for (Map.Entry<String, String> mmlAttribute : getAttributes().entrySet()) {
       if (mmlAttribute.getKey().equals(ID_ATTR)) {
         pmlAttributes.put(mmlAttribute.getKey(), getPresentationMlIdAttribute());

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
@@ -67,15 +67,9 @@ public class Dialog extends Element {
     switch (item.getNodeName()) {
       case DATA_ATTRIBUTE_PREFIX + WIDTH_ATTR:
       case WIDTH_ATTR:
-//        setAttribute(WIDTH_ATTR, item.getNodeValue());
-//        break;
       case DATA_ATTRIBUTE_PREFIX + STATE_ATTR:
       case STATE_ATTR:
-//        setAttribute(STATE_ATTR, item.getNodeValue());
-//        break;
       case DATA_ATTRIBUTE_PREFIX + OPEN_ATTR:
-//        setAttribute(OPEN_ATTR, item.getNodeValue());
-//        break;
       case ID_ATTR:
         setAttribute(item.getNodeName().replace(DATA_ATTRIBUTE_PREFIX, ""), item.getNodeValue());
         break;

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Dialog.java
@@ -65,13 +65,24 @@ public class Dialog extends Element {
   @Override
   protected void buildAttribute(MessageMLParser parser, Node item) throws InvalidInputException {
     switch (item.getNodeName()) {
-      case ID_ATTR:
-      case WIDTH_ATTR:
-      case STATE_ATTR:
-      case OPEN_ATTR:
-      case DATA_ATTRIBUTE_PREFIX + STATE_ATTR:
       case DATA_ATTRIBUTE_PREFIX + WIDTH_ATTR:
+      case WIDTH_ATTR:
+//        setAttribute(WIDTH_ATTR, item.getNodeValue());
+//        break;
+      case DATA_ATTRIBUTE_PREFIX + STATE_ATTR:
+      case STATE_ATTR:
+//        setAttribute(STATE_ATTR, item.getNodeValue());
+//        break;
       case DATA_ATTRIBUTE_PREFIX + OPEN_ATTR:
+//        setAttribute(OPEN_ATTR, item.getNodeValue());
+//        break;
+      case ID_ATTR:
+        setAttribute(item.getNodeName().replace(DATA_ATTRIBUTE_PREFIX, ""), item.getNodeValue());
+        break;
+      case OPEN_ATTR:
+        if (format == FormatEnum.MESSAGEML) {
+          throwInvalidInputException(item);
+        }
         setAttribute(item.getNodeName(), item.getNodeValue());
         break;
       default:
@@ -155,10 +166,15 @@ public class Dialog extends Element {
   private Map<String, String> getPresentationMLAttributes() {
     Map<String, String> pmlAttributes = new HashMap<>();
 
-    pmlAttributes.put(OPEN_ATTR, "");
+    if (this.format == FormatEnum.MESSAGEML) {
+      pmlAttributes.put(OPEN_ATTR, "");
+    }
+
     for (Map.Entry<String, String> mmlAttribute : getAttributes().entrySet()) {
       if (mmlAttribute.getKey().equals(ID_ATTR)) {
         pmlAttributes.put(mmlAttribute.getKey(), getPresentationMlIdAttribute());
+      } else if (mmlAttribute.getKey().equals(OPEN_ATTR)) {
+        pmlAttributes.put(OPEN_ATTR, "");
       } else {
         pmlAttributes.put(DATA_ATTRIBUTE_PREFIX + mmlAttribute.getKey(), mmlAttribute.getValue());
       }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DialogChild.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DialogChild.java
@@ -1,11 +1,11 @@
 package org.symphonyoss.symphony.messageml.elements;
 
+import org.commonmark.node.Node;
+import org.commonmark.node.Paragraph;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -63,8 +63,6 @@ public abstract class DialogChild extends Element {
     assertNoAttributes();
     assertParent(list);
 
-
-
     boolean containsDialog = getChildren().stream().anyMatch(e -> e instanceof Dialog);
     if (containsDialog) {
       throw new InvalidInputException(getMessageMLTag() + " should not contain a dialog");
@@ -85,5 +83,10 @@ public abstract class DialogChild extends Element {
       child.asPresentationML(out, context);
     }
     out.closeElement();
+  }
+
+  @Override
+  Node asMarkdown() throws InvalidInputException {
+    return new Paragraph();
   }
 }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -668,7 +668,7 @@ public abstract class Element {
   }
 
   /**
-   * Check that the element's children are limited to allowed element types.
+   * Check that the element's children match the given {@link Predicate} function.
    */
   void assertContentModel(Predicate<Element> permittedChildrenPredicate, Function<Element, String> errorMessage) throws InvalidInputException {
     for (Element child : this.getChildren()) {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/ExpandableCard.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/ExpandableCard.java
@@ -39,10 +39,10 @@ import java.util.Map;
 public class ExpandableCard extends Element {
 
   public static final String MESSAGEML_TAG = "expandable-card";
+  public static final String PRESENTATIONML_STATE_ATTR = "data-state";
   public static final String PRESENTATIONML_CLASS = "expandable-card";
   private static final String PRESENTATIONML_TAG = "div";
   private static final String ATTR_STATE = "state";
-  private static final String PRESENTATIONML_STATE = "data-state";
   private static final String COLLAPSED = "collapsed";
   private static final String CROPPED = "cropped";
   private static final String EXPANDED = "expanded";
@@ -53,10 +53,9 @@ public class ExpandableCard extends Element {
   }
 
   @Override
-  protected void buildAttribute(MessageMLParser parser,
-      Node item) throws InvalidInputException {
+  protected void buildAttribute(MessageMLParser parser, Node item) throws InvalidInputException {
     switch (item.getNodeName()) {
-      case PRESENTATIONML_STATE:
+      case PRESENTATIONML_STATE_ATTR:
       case ATTR_STATE:
         setAttribute(ATTR_STATE, getStringAttribute(item));
         break;
@@ -75,7 +74,7 @@ public class ExpandableCard extends Element {
       presentationAttrs.put(CLASS_ATTR, PRESENTATIONML_CLASS);
     }
     if (getAttribute(ATTR_STATE) != null) {
-      presentationAttrs.put(PRESENTATIONML_STATE, getAttribute(ATTR_STATE));
+      presentationAttrs.put(PRESENTATIONML_STATE_ATTR, getAttribute(ATTR_STATE));
     }
 
     out.openElement(PRESENTATIONML_TAG, presentationAttrs);

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/ExpandableCardBody.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/ExpandableCardBody.java
@@ -39,9 +39,9 @@ public class ExpandableCardBody extends Element {
 
   public static final String MESSAGEML_TAG = "body";
   public static final String PRESENTATIONML_CLASS = "expandableCardBody";
+  public static final String PRESENTATIONML_VARIANT_ATTR = "data-variant";
   private static final String PRESENTATIONML_TAG = "div";
   private static final String ATTR_VARIANT = "variant";
-  private static final String PRESENTATIONML_VARIANT = "data-variant";
   private static final List<String> allowedVariants = Arrays.asList("default", "error");
 
   public ExpandableCardBody(Element parent, FormatEnum format) {
@@ -49,10 +49,9 @@ public class ExpandableCardBody extends Element {
   }
 
   @Override
-  void buildAttribute(MessageMLParser parser,
-      org.w3c.dom.Node item) throws InvalidInputException {
+  void buildAttribute(MessageMLParser parser, org.w3c.dom.Node item) throws InvalidInputException {
     switch (item.getNodeName()) {
-      case PRESENTATIONML_VARIANT:
+      case PRESENTATIONML_VARIANT_ATTR:
       case ATTR_VARIANT:
         setAttribute(ATTR_VARIANT, getStringAttribute(item));
         break;
@@ -67,7 +66,7 @@ public class ExpandableCardBody extends Element {
     Map<String, String> presentationAttrs = new LinkedHashMap<>();
     presentationAttrs.put(CLASS_ATTR, PRESENTATIONML_CLASS);
     if (getAttribute(ATTR_VARIANT) != null) {
-      presentationAttrs.put(PRESENTATIONML_VARIANT, getAttribute(ATTR_VARIANT));
+      presentationAttrs.put(PRESENTATIONML_VARIANT_ATTR, getAttribute(ATTR_VARIANT));
     }
     out.openElement(PRESENTATIONML_TAG, presentationAttrs);
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Form.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Form.java
@@ -57,7 +57,13 @@ public class Form extends Element {
     if (!getParent().getClass().equals(Dialog.class)) {
       assertAtLeastOneActionButton();
     } else {
-      assertContentModel(Arrays.asList(DialogChild.Footer.class, DialogChild.Title.class, DialogChild.Body.class));
+      if (format == FormatEnum.MESSAGEML) {
+        assertContentModel(Arrays.asList(DialogChild.Footer.class, DialogChild.Title.class, DialogChild.Body.class));
+      } else {
+        assertContentModel(
+            e -> e.isPresentationMLElement("dialog-title") || e.isPresentationMLElement("dialog-body") || e.isPresentationMLElement("dialog-footer"),
+            child -> "Element \"" + child.getMessageMLTag() + "\" is not allowed in \"" + this.getMessageMLTag() + "\"");
+      }
     }
     if(getAttribute(MULTI_SUBMIT) != null) {
       assertAttributeMaxLength(MULTI_SUBMIT, MAX_LENGTH);

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TimePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TimePicker.java
@@ -85,6 +85,7 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
           throwInvalidInputException(item);
         }
         fillAttributes(parser, item);
+        setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       default:
         throwInvalidInputException(item);
@@ -283,6 +284,16 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
     }
     if (getAttribute(REQUIRED_ATTR) != null) {
       presentationAttrs.put(REQUIRED_ATTR, getAttribute(REQUIRED_ATTR));
+    }
+    // PresentationML compatibility
+    if (getAttribute(PRESENTATIONML_FORMAT_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_FORMAT_ATTR, getAttribute(PRESENTATIONML_FORMAT_ATTR));
+    }
+    if (getAttribute(PRESENTATIONML_STRICT_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_STRICT_ATTR, getAttribute(PRESENTATIONML_STRICT_ATTR));
+    }
+    if (getAttribute(PRESENTATIONML_DISABLED_TIME_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_DISABLED_TIME_ATTR, getAttribute(PRESENTATIONML_DISABLED_TIME_ATTR));
     }
     return presentationAttrs;
   }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TimePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TimePicker.java
@@ -36,9 +36,9 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
   private static final String FORMAT_ATTR = "format";
 
   // PresentationML specific attributes
-  private static final String FORMAT_PRESENTATION_ATTR = "data-format";
-  private static final String DISABLED_TIME_PRESENTATION_ATTR = "data-disabled-time";
-  private static final String STRICT_PRESENTATION_ATTR = "data-strict";
+  private static final String PRESENTATIONML_FORMAT_ATTR = "data-format";
+  private static final String PRESENTATIONML_DISABLED_TIME_ATTR = "data-disabled-time";
+  private static final String PRESENTATIONML_STRICT_ATTR = "data-strict";
 
   private static final int DISABLED_TIME_RANGE_MAX_LENGTH = 1024;
   private static final int DEFAULT_MAX_LENGTH = 64;
@@ -76,9 +76,11 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
         }
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
+      case TYPE_ATTR:
       case ID_ATTR:
-      case DISABLED_TIME_PRESENTATION_ATTR:
-      case FORMAT_PRESENTATION_ATTR:
+      case PRESENTATIONML_DISABLED_TIME_ATTR:
+      case PRESENTATIONML_STRICT_ATTR:
+      case PRESENTATIONML_FORMAT_ATTR:
         if (this.format != FormatEnum.PRESENTATIONML) {
           throwInvalidInputException(item);
         }
@@ -271,13 +273,13 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
       presentationAttrs.put(STEP_ATTR, getAttribute(STEP_ATTR));
     }
     if (getAttribute(FORMAT_ATTR) != null) {
-      presentationAttrs.put(FORMAT_PRESENTATION_ATTR, getAttribute(FORMAT_ATTR));
+      presentationAttrs.put(PRESENTATIONML_FORMAT_ATTR, getAttribute(FORMAT_ATTR));
     }
     if (getAttribute(STRICT_ATTR) != null) {
-      presentationAttrs.put(STRICT_PRESENTATION_ATTR, getAttribute(STRICT_ATTR));
+      presentationAttrs.put(PRESENTATIONML_STRICT_ATTR, getAttribute(STRICT_ATTR));
     }
     if (getAttribute(DISABLED_TIME_ATTR) != null) {
-      presentationAttrs.put(DISABLED_TIME_PRESENTATION_ATTR, convertJsonTimeToPresentationML(DISABLED_TIME_ATTR));
+      presentationAttrs.put(PRESENTATIONML_DISABLED_TIME_ATTR, convertJsonTimeToPresentationML(DISABLED_TIME_ATTR));
     }
     if (getAttribute(REQUIRED_ATTR) != null) {
       presentationAttrs.put(REQUIRED_ATTR, getAttribute(REQUIRED_ATTR));

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TimezonePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TimezonePicker.java
@@ -35,7 +35,6 @@ import java.util.Map;
  *   Value attribute and timezones defined in the disabled-timezone should be valid and belonging to the
  *   "tz database"
  */
-
 public class TimezonePicker extends FormElement implements LabelableElement, TooltipableElement {
 
   public static final String MESSAGEML_TAG = "timezone-picker";
@@ -46,11 +45,11 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
   private static final String DISABLED_TIMEZONE_ATTR = "disabled-timezone";
 
   public static final String PRESENTATIONML_CLASS = MESSAGEML_TAG;
-  private static final String PRESENTATIONML_NAME_ATTR = "data-name";
-  private static final String PRESENTATIONML_VALUE_ATTR = "data-value";
-  private static final String PRESENTATIONML_REQUIRED_ATTR = "data-required";
-  private static final String PRESENTATIONML_PLACEHOLDER_ATTR = "data-placeholder";
-  private static final String PRESENTATIONML_DISABLED_TIMEZONE_ATTR = "data-disabled-timezone";
+  private static final String NAME_PRESENTATION_ATTR = "data-name";
+  private static final String VALUE_PRESENTATION_ATTR = "data-value";
+  private static final String REQUIRED_PRESENTATION_ATTR = "data-required";
+  private static final String PLACEHOLDER_PRESENTATION_ATTR = "data-placeholder";
+  private static final String DISABLED_TIMEZONE_PRESENTATION_ATTR = "data-disabled-timezone";
 
   private static final int DISABLED_TIMEZONE_MAX_LENGTH = 1024;
   private static final String PRESENTATIONML_TAG = "div";
@@ -62,32 +61,33 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
 
   @Override
   protected void buildAttribute(MessageMLParser parser,
-                                Node item) throws InvalidInputException {
+      Node item) throws InvalidInputException {
     switch (item.getNodeName()) {
       case NAME_ATTR:
-      case PRESENTATIONML_NAME_ATTR:
-        setAttribute(NAME_ATTR, getStringAttribute(item));
-        break;
       case VALUE_ATTR:
-      case PRESENTATIONML_VALUE_ATTR:
-        setAttribute(VALUE_ATTR, getStringAttribute(item));
-        break;
-      case REQUIRED_ATTR:
-      case PRESENTATIONML_REQUIRED_ATTR:
-        setAttribute(REQUIRED_ATTR, getStringAttribute(item));
-        break;
-      case PLACEHOLDER_ATTR:
-      case PRESENTATIONML_PLACEHOLDER_ATTR:
-        setAttribute(PLACEHOLDER_ATTR, getStringAttribute(item));
-        break;
-      case DISABLED_TIMEZONE_ATTR:
-      case PRESENTATIONML_DISABLED_TIMEZONE_ATTR:
-        setAttribute(DISABLED_TIMEZONE_ATTR, getStringAttribute(item));
-        break;
-      case ID_ATTR:
       case TITLE:
       case LABEL:
+      case REQUIRED_ATTR:
+      case PLACEHOLDER_ATTR:
         setAttribute(item.getNodeName(), getStringAttribute(item));
+        break;
+      case DISABLED_TIMEZONE_ATTR:
+        if (this.format != FormatEnum.MESSAGEML) {
+          throwInvalidInputException(item);
+        }
+        setAttribute(item.getNodeName(), getStringAttribute(item));
+        break;
+      case ID_ATTR:
+      case VALUE_PRESENTATION_ATTR:
+      case NAME_PRESENTATION_ATTR:
+      case REQUIRED_PRESENTATION_ATTR:
+      case PLACEHOLDER_PRESENTATION_ATTR:
+      case DISABLED_TIMEZONE_PRESENTATION_ATTR:
+        if (this.format != FormatEnum.PRESENTATIONML) {
+          throwInvalidInputException(item);
+        }
+        setAttribute(item.getNodeName(), getStringAttribute(item));
+        fillAttributes(parser, item);
         break;
       default:
         throwInvalidInputException(item);
@@ -97,7 +97,8 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
   @Override
   public void validate() throws InvalidInputException {
     super.validate();
-    assertAttributeNotBlank(NAME_ATTR);
+
+    assertAttributeNotBlank(this.format == FormatEnum.MESSAGEML ? NAME_ATTR : NAME_PRESENTATION_ATTR);
 
     if (getAttribute(REQUIRED_ATTR) != null) {
       assertAttributeValue(REQUIRED_ATTR, Arrays.asList("true", "false"));
@@ -116,19 +117,19 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
     if (disabledTimezones == null) return;
     try {
       List<String> timezones = MAPPER.readValue(disabledTimezones,
-              MAPPER.getTypeFactory().constructCollectionType(List.class, String.class));
+          MAPPER.getTypeFactory().constructCollectionType(List.class, String.class));
       for (String timezone : timezones) {
         assertTimezoneValid(attributeName, timezone);
       }
     } catch (JsonProcessingException e) {
       throw new InvalidInputException(
-              String.format("Error parsing json in attribute \"%s\". It should contain an array of Strings",
-                      attributeName), e);
+          String.format("Error parsing json in attribute \"%s\". It should contain an array of Strings",
+              attributeName), e);
     }
   }
 
   private void assertTimezoneValid(String attributeValue, String timezone)
-          throws InvalidInputException {
+      throws InvalidInputException {
     try {
       ZoneId.of(timezone);
     } catch (DateTimeException e) {
@@ -137,8 +138,7 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
   }
 
   @Override
-  public void asPresentationML(XmlPrintStream out,
-                               MessageMLContext context) {
+  public void asPresentationML(XmlPrintStream out, MessageMLContext context) {
     Map<String, Object> presentationAttrs = buildTimezonePickerInputAttributes();
     if (isSplittable()) {
       // open div + adding splittable elements
@@ -177,7 +177,11 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
 
   @Override
   public org.commonmark.node.Node asMarkdown() {
-    return new TimezonePickerNode(getAttribute(LABEL), getAttribute(TITLE), getAttribute(PLACEHOLDER_ATTR));
+    return new TimezonePickerNode(
+        getAttribute(LABEL),
+        getAttribute(TITLE),
+        this.format == FormatEnum.MESSAGEML ? getAttribute(PLACEHOLDER_ATTR) : getAttribute(PLACEHOLDER_PRESENTATION_ATTR)
+    );
   }
 
   private void innerAsPresentationML(XmlPrintStream out, Map<String, Object> presentationAttrs) {
@@ -189,29 +193,46 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
     Map<String, Object> presentationAttrs = new LinkedHashMap<>();
 
     presentationAttrs.put(CLASS_ATTR, MESSAGEML_TAG);
-    presentationAttrs.put(PRESENTATIONML_NAME_ATTR, getAttribute(NAME_ATTR));
 
+    if (getAttribute(NAME_ATTR) != null) {
+      presentationAttrs.put(NAME_PRESENTATION_ATTR, getAttribute(NAME_ATTR));
+    }
     if (getAttribute(VALUE_ATTR) != null) {
-      presentationAttrs.put(PRESENTATIONML_VALUE_ATTR, getAttribute(VALUE_ATTR));
+      presentationAttrs.put(VALUE_PRESENTATION_ATTR, getAttribute(VALUE_ATTR));
     }
     if (getAttribute(PLACEHOLDER_ATTR) != null) {
-      presentationAttrs.put(PRESENTATIONML_PLACEHOLDER_ATTR, getAttribute(PLACEHOLDER_ATTR));
+      presentationAttrs.put(PLACEHOLDER_PRESENTATION_ATTR, getAttribute(PLACEHOLDER_ATTR));
     }
-
     if (getAttribute(DISABLED_TIMEZONE_ATTR) != null) {
-      presentationAttrs.put(PRESENTATIONML_DISABLED_TIMEZONE_ATTR, convertJsonTimezoneToPresentationML(DISABLED_TIMEZONE_ATTR));
+      presentationAttrs.put(DISABLED_TIMEZONE_PRESENTATION_ATTR, convertJsonTimezoneToPresentationML(DISABLED_TIMEZONE_ATTR));
+    }
+    if (getAttribute(REQUIRED_ATTR) != null) {
+      presentationAttrs.put(REQUIRED_PRESENTATION_ATTR, getAttribute(REQUIRED_ATTR));
     }
 
-    if (getAttribute(REQUIRED_ATTR) != null) {
-      presentationAttrs.put(PRESENTATIONML_REQUIRED_ATTR, getAttribute(REQUIRED_ATTR));
+    if (getAttribute(NAME_PRESENTATION_ATTR) != null) {
+      presentationAttrs.put(NAME_PRESENTATION_ATTR, getAttribute(NAME_PRESENTATION_ATTR));
     }
+    if (getAttribute(VALUE_PRESENTATION_ATTR) != null) {
+      presentationAttrs.put(VALUE_PRESENTATION_ATTR, getAttribute(VALUE_PRESENTATION_ATTR));
+    }
+    if (getAttribute(PLACEHOLDER_PRESENTATION_ATTR) != null) {
+      presentationAttrs.put(PLACEHOLDER_PRESENTATION_ATTR, getAttribute(PLACEHOLDER_PRESENTATION_ATTR));
+    }
+    if (getAttribute(DISABLED_TIMEZONE_PRESENTATION_ATTR) != null) {
+      presentationAttrs.put(DISABLED_TIMEZONE_PRESENTATION_ATTR, convertJsonTimezoneToPresentationML(DISABLED_TIMEZONE_PRESENTATION_ATTR));
+    }
+    if (getAttribute(REQUIRED_PRESENTATION_ATTR) != null) {
+      presentationAttrs.put(REQUIRED_PRESENTATION_ATTR, getAttribute(REQUIRED_PRESENTATION_ATTR));
+    }
+
     return presentationAttrs;
   }
 
   private XMLAttribute convertJsonTimezoneToPresentationML(String attributeName) {
     try {
       List<String> timezones = MAPPER.readValue(getAttribute(attributeName),
-              MAPPER.getTypeFactory().constructCollectionType(List.class, String.class));
+          MAPPER.getTypeFactory().constructCollectionType(List.class, String.class));
       String result = MAPPER.writeValueAsString(timezones);
       return XMLAttribute.of(result, XMLAttribute.Format.JSON);
     } catch (JsonProcessingException e) {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TimezonePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TimezonePicker.java
@@ -45,11 +45,12 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
   private static final String PLACEHOLDER_ATTR = "placeholder";
   private static final String DISABLED_TIMEZONE_ATTR = "disabled-timezone";
 
-  private static final String NAME_PRESENTATION_ATTR = "data-name";
-  private static final String VALUE_PRESENTATION_ATTR = "data-value";
-  private static final String REQUIRED_PRESENTATION_ATTR = "data-required";
-  private static final String PLACEHOLDER_PRESENTATION_ATTR = "data-placeholder";
-  private static final String DISABLED_TIMEZONE_PRESENTATION_ATTR = "data-disabled-timezone";
+  public static final String PRESENTATIONML_CLASS = MESSAGEML_TAG;
+  private static final String PRESENTATIONML_NAME_ATTR = "data-name";
+  private static final String PRESENTATIONML_VALUE_ATTR = "data-value";
+  private static final String PRESENTATIONML_REQUIRED_ATTR = "data-required";
+  private static final String PRESENTATIONML_PLACEHOLDER_ATTR = "data-placeholder";
+  private static final String PRESENTATIONML_DISABLED_TIMEZONE_ATTR = "data-disabled-timezone";
 
   private static final int DISABLED_TIMEZONE_MAX_LENGTH = 1024;
   private static final String PRESENTATIONML_TAG = "div";
@@ -64,29 +65,29 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
                                 Node item) throws InvalidInputException {
     switch (item.getNodeName()) {
       case NAME_ATTR:
+      case PRESENTATIONML_NAME_ATTR:
+        setAttribute(NAME_ATTR, getStringAttribute(item));
+        break;
       case VALUE_ATTR:
-      case TITLE:
-      case LABEL:
+      case PRESENTATIONML_VALUE_ATTR:
+        setAttribute(VALUE_ATTR, getStringAttribute(item));
+        break;
       case REQUIRED_ATTR:
+      case PRESENTATIONML_REQUIRED_ATTR:
+        setAttribute(REQUIRED_ATTR, getStringAttribute(item));
+        break;
       case PLACEHOLDER_ATTR:
-        setAttribute(item.getNodeName(), getStringAttribute(item));
+      case PRESENTATIONML_PLACEHOLDER_ATTR:
+        setAttribute(PLACEHOLDER_ATTR, getStringAttribute(item));
         break;
       case DISABLED_TIMEZONE_ATTR:
-        if (this.format != FormatEnum.MESSAGEML) {
-          throwInvalidInputException(item);
-        }
-        setAttribute(item.getNodeName(), getStringAttribute(item));
+      case PRESENTATIONML_DISABLED_TIMEZONE_ATTR:
+        setAttribute(DISABLED_TIMEZONE_ATTR, getStringAttribute(item));
         break;
       case ID_ATTR:
-      case VALUE_PRESENTATION_ATTR:
-      case NAME_PRESENTATION_ATTR:
-      case REQUIRED_PRESENTATION_ATTR:
-      case PLACEHOLDER_PRESENTATION_ATTR:
-      case DISABLED_TIMEZONE_PRESENTATION_ATTR:
-        if (this.format != FormatEnum.PRESENTATIONML) {
-          throwInvalidInputException(item);
-        }
-        fillAttributes(parser, item);
+      case TITLE:
+      case LABEL:
+        setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       default:
         throwInvalidInputException(item);
@@ -188,21 +189,21 @@ public class TimezonePicker extends FormElement implements LabelableElement, Too
     Map<String, Object> presentationAttrs = new LinkedHashMap<>();
 
     presentationAttrs.put(CLASS_ATTR, MESSAGEML_TAG);
-    presentationAttrs.put(NAME_PRESENTATION_ATTR, getAttribute(NAME_ATTR));
+    presentationAttrs.put(PRESENTATIONML_NAME_ATTR, getAttribute(NAME_ATTR));
 
     if (getAttribute(VALUE_ATTR) != null) {
-      presentationAttrs.put(VALUE_PRESENTATION_ATTR, getAttribute(VALUE_ATTR));
+      presentationAttrs.put(PRESENTATIONML_VALUE_ATTR, getAttribute(VALUE_ATTR));
     }
     if (getAttribute(PLACEHOLDER_ATTR) != null) {
-      presentationAttrs.put(PLACEHOLDER_PRESENTATION_ATTR, getAttribute(PLACEHOLDER_ATTR));
+      presentationAttrs.put(PRESENTATIONML_PLACEHOLDER_ATTR, getAttribute(PLACEHOLDER_ATTR));
     }
 
     if (getAttribute(DISABLED_TIMEZONE_ATTR) != null) {
-      presentationAttrs.put(DISABLED_TIMEZONE_PRESENTATION_ATTR, convertJsonTimezoneToPresentationML(DISABLED_TIMEZONE_ATTR));
+      presentationAttrs.put(PRESENTATIONML_DISABLED_TIMEZONE_ATTR, convertJsonTimezoneToPresentationML(DISABLED_TIMEZONE_ATTR));
     }
 
     if (getAttribute(REQUIRED_ATTR) != null) {
-      presentationAttrs.put(REQUIRED_PRESENTATION_ATTR, getAttribute(REQUIRED_ATTR));
+      presentationAttrs.put(PRESENTATIONML_REQUIRED_ATTR, getAttribute(REQUIRED_ATTR));
     }
     return presentationAttrs;
   }

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/UIAction.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/UIAction.java
@@ -49,12 +49,13 @@ public class UIAction extends Element {
   private static final int MAX_USER_IDS = 15;
 
   private static final String PRESENTATIONML_TAG = "div";
+  public static final String PRESENTATIONML_CLASS = MESSAGEML_TAG;
   private static final String PRESENTATIONML_ACTION_ATTR = "data-action";
   private static final String PRESENTATIONML_TRIGGER_ATTR = "data-trigger";
   private static final String PRESENTATIONML_USER_IDS_ATTR = "data-user-ids";
   private static final String PRESENTATIONML_STREAM_ID_ATTR = "data-stream-id";
   private static final String PRESENTATIONML_SIDE_BY_SIDE_ATTR = "data-side-by-side";
-  private static final String DATA_TARGET_ID = "data-target-id";
+  private static final String PRESENTATIONML_DATA_TARGET_ID_ATTR = "data-target-id";
 
   public UIAction(Element parent, FormatEnum format) {
     super(parent, MESSAGEML_TAG, format);
@@ -65,15 +66,28 @@ public class UIAction extends Element {
   protected void buildAttribute(MessageMLParser parser, org.w3c.dom.Node item) throws InvalidInputException {
     switch (item.getNodeName()) {
       case ACTION_ATTR:
+      case PRESENTATIONML_ACTION_ATTR:
+        setAttribute(ACTION_ATTR, getStringAttribute(item));
+        break;
       case TRIGGER_ATTR:
+      case PRESENTATIONML_TRIGGER_ATTR:
+        setAttribute(TRIGGER_ATTR, getStringAttribute(item));
+        break;
       case USER_IDS_ATTR:
+      case PRESENTATIONML_USER_IDS_ATTR:
+        setAttribute(USER_IDS_ATTR, getStringAttribute(item));
+        break;
       case STREAM_ID_ATTR:
+      case PRESENTATIONML_STREAM_ID_ATTR:
+        setAttribute(STREAM_ID_ATTR, getStringAttribute(item));
+        break;
       case SIDE_BY_SIDE_ATTR:
+      case PRESENTATIONML_SIDE_BY_SIDE_ATTR:
+        setAttribute(SIDE_BY_SIDE_ATTR, getStringAttribute(item));
+        break;
       case TARGET_ID:
-        if (this.format != FormatEnum.MESSAGEML) {
-          throwInvalidInputException(item);
-        }
-        setAttribute(item.getNodeName(), getStringAttribute(item));
+      case PRESENTATIONML_DATA_TARGET_ID_ATTR:
+        setAttribute(TARGET_ID, getStringAttribute(item));
         break;
       default:
         throwInvalidInputException(item);
@@ -186,7 +200,7 @@ public class UIAction extends Element {
       presentationAttrs.put(PRESENTATIONML_SIDE_BY_SIDE_ATTR, getAttribute(SIDE_BY_SIDE_ATTR));
     }
     if (getAttribute(TARGET_ID) != null) {
-      presentationAttrs.put(DATA_TARGET_ID, getAttribute(TARGET_ID));
+      presentationAttrs.put(PRESENTATIONML_DATA_TARGET_ID_ATTR, getAttribute(TARGET_ID));
     }
 
     return presentationAttrs;

--- a/src/main/java/org/symphonyoss/symphony/messageml/exceptions/InvalidInputException.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/exceptions/InvalidInputException.java
@@ -30,6 +30,10 @@ public class InvalidInputException extends MessageMLException {
     super(message);
   }
 
+  public InvalidInputException(String message, Object... args) {
+    super(String.format(message, args));
+  }
+
   public InvalidInputException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/src/test/java/org/symphonyoss/symphony/messageml/Mml2Pml.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/Mml2Pml.java
@@ -1,0 +1,131 @@
+package org.symphonyoss.symphony.messageml;
+
+import static org.apache.commons.io.FilenameUtils.getBaseName;
+import static org.apache.commons.io.FilenameUtils.isExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.symphonyoss.symphony.messageml.elements.MessageML;
+import org.symphonyoss.symphony.messageml.util.IDataProvider;
+import org.symphonyoss.symphony.messageml.util.TestDataProvider;
+import org.w3c.dom.Node;
+import org.w3c.dom.bootstrap.DOMImplementationRegistry;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSSerializer;
+import org.xml.sax.InputSource;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+@Slf4j
+public class Mml2Pml {
+
+  private static final String EXAMPLES = "/examples/";
+
+  @ParameterizedTest(name = "File {0}")
+  @MethodSource("examples")
+  void mml2Pml2Pml(String file, String message, String entityJson) throws Exception {
+
+    log.info("\n----\n### EXAMPLE({})", file);
+    log.info("1 # MML:\n{}\n{}{}", LINE, prettyXml(message), LINE);
+    //
+    // STEP 1 / MML -> PML
+    //
+    log.info("1 # MML -> PML:");
+    MessageMLContext context = parse(message, entityJson);
+    log.info("\n{}\n{}{}", LINE, prettyXml(context.getPresentationML()), LINE);
+    //
+    // STEP 2 / PML -> PML
+    //
+    log.info("2 # PML -> PML:");
+    context = parse(context.getPresentationML(), context.getEntityJson());
+    context.getText();
+    log.info("\n{}\n{}{}", LINE, prettyXml(context.getPresentationML()), LINE);
+  }
+
+  @SneakyThrows
+  private static Stream<Arguments> examples() {
+    return getExamples()
+        .stream()
+        .filter(file -> isExtension(file, "xml"))
+        .map(file -> Arguments.of(file, load(file), load(EXAMPLES + getBaseName(file) + ".json")));
+  }
+
+  @SneakyThrows
+  private static List<String> getExamples() {
+    List<String> filenames = new ArrayList<>();
+
+    try (
+        InputStream in = Mml2Pml.class.getResourceAsStream(EXAMPLES);
+        BufferedReader br = new BufferedReader(new InputStreamReader(Objects.requireNonNull(in)))) {
+        String resource;
+
+      while ((resource = br.readLine()) != null) {
+        filenames.add(resource);
+      }
+    }
+
+    return filenames.stream().map(file -> EXAMPLES + file).collect(Collectors.toList());
+  }
+
+  @SneakyThrows
+  private static MessageMLContext parse(String message, ObjectNode entityJson) {
+    return parse(message, new ObjectMapper().writeValueAsString(entityJson));
+  }
+
+  @SneakyThrows
+  private static MessageMLContext parse(String message, String entityJson) {
+    MessageMLContext context = new MessageMLContext(createDataProvider());
+    context.parseMessageML(message, entityJson, MessageML.MESSAGEML_VERSION);
+    return context;
+  }
+
+  private static String prettyXml(String input) {
+    try {
+      final InputSource src = new InputSource(new StringReader(input));
+      final Node document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(src).getDocumentElement();
+      final DOMImplementationRegistry registry = DOMImplementationRegistry.newInstance();
+      final DOMImplementationLS impl = (DOMImplementationLS) registry.getDOMImplementation("LS");
+      final LSSerializer writer = impl.createLSSerializer();
+      writer.getDomConfig().setParameter("format-pretty-print", Boolean.TRUE);
+      writer.getDomConfig().setParameter("xml-declaration", false);
+      return writer.writeToString(document);
+    } catch (Exception ex) {
+      log.warn("Cannot prettify XML input: {}", ex.getMessage());
+      return input;
+    }
+  }
+
+  private static String load(String classpathFile) {
+    try {
+      return IOUtils.toString(Mml2Pml.class.getResourceAsStream(classpathFile), StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private static IDataProvider createDataProvider() {
+    final TestDataProvider dataProvider = new TestDataProvider();
+    dataProvider.setUserPresentation(123456, "Foo Bar", "Foo Bar", "test@symphony.com");
+    return dataProvider;
+  }
+
+  private static final String LINE =
+      "########################################################################################################################################################################################################################################";
+}

--- a/src/test/java/org/symphonyoss/symphony/messageml/Mml2Pml2Pml.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/Mml2Pml2Pml.java
@@ -3,6 +3,7 @@ package org.symphonyoss.symphony.messageml;
 import static org.apache.commons.io.FilenameUtils.getBaseName;
 import static org.apache.commons.io.FilenameUtils.isExtension;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.symphonyoss.symphony.messageml.util.XmlUtils.prettyXml;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -14,11 +15,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.symphonyoss.symphony.messageml.elements.MessageML;
 import org.symphonyoss.symphony.messageml.util.IDataProvider;
 import org.symphonyoss.symphony.messageml.util.TestDataProvider;
-import org.w3c.dom.Node;
-import org.w3c.dom.bootstrap.DOMImplementationRegistry;
-import org.w3c.dom.ls.DOMImplementationLS;
-import org.w3c.dom.ls.LSSerializer;
-import org.xml.sax.InputSource;
 import org.xmlunit.builder.Input;
 import org.xmlunit.diff.Comparison;
 import org.xmlunit.diff.ComparisonResult;
@@ -29,7 +25,6 @@ import org.xmlunit.diff.DifferenceEngine;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,8 +32,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.xml.parsers.DocumentBuilderFactory;
 
 /**
  * This test loads a set of MessageML files from classpath:/examples location and performs 2 successive transformation:
@@ -131,22 +124,6 @@ public class Mml2Pml2Pml {
     MessageMLContext context = new MessageMLContext(createDataProvider());
     context.parseMessageML(message, entityJson, MessageML.MESSAGEML_VERSION);
     return context;
-  }
-
-  private static String prettyXml(String input) {
-    try {
-      final InputSource src = new InputSource(new StringReader(input));
-      final Node document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(src).getDocumentElement();
-      final DOMImplementationRegistry registry = DOMImplementationRegistry.newInstance();
-      final DOMImplementationLS impl = (DOMImplementationLS) registry.getDOMImplementation("LS");
-      final LSSerializer writer = impl.createLSSerializer();
-      writer.getDomConfig().setParameter("format-pretty-print", Boolean.TRUE);
-      writer.getDomConfig().setParameter("xml-declaration", false);
-      return writer.writeToString(document);
-    } catch (Exception ex) {
-      System.out.printf("Cannot prettify XML input: %s", ex.getMessage());
-      return input;
-    }
   }
 
   private static String load(String classpathFile) {

--- a/src/test/java/org/symphonyoss/symphony/messageml/Mml2Pml2Pml.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/Mml2Pml2Pml.java
@@ -33,8 +33,16 @@ import java.util.stream.Stream;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
+/**
+ * This test loads a set of MessageML files from classpath:/examples location and performs 2 successive transformation:
+ * <ul>
+ *   <li>MessageML -> PresentationML</li>
+ *   <li>PresentationML -> PresentationML</li>
+ * </ul>
+ * It allows to ensure that generated PresentationML is an actual MessageML valid one.
+ */
 @Slf4j
-public class Mml2Pml {
+public class Mml2Pml2Pml {
 
   private static final String EXAMPLES = "/examples/";
 
@@ -72,7 +80,7 @@ public class Mml2Pml {
     List<String> filenames = new ArrayList<>();
 
     try (
-        InputStream in = Mml2Pml.class.getResourceAsStream(EXAMPLES);
+        InputStream in = Mml2Pml2Pml.class.getResourceAsStream(EXAMPLES);
         BufferedReader br = new BufferedReader(new InputStreamReader(Objects.requireNonNull(in)))) {
         String resource;
 
@@ -114,7 +122,7 @@ public class Mml2Pml {
 
   private static String load(String classpathFile) {
     try {
-      return IOUtils.toString(Mml2Pml.class.getResourceAsStream(classpathFile), StandardCharsets.UTF_8);
+      return IOUtils.toString(Mml2Pml2Pml.class.getResourceAsStream(classpathFile), StandardCharsets.UTF_8);
     } catch (Exception e) {
       return null;
     }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/DialogTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/DialogTest.java
@@ -335,9 +335,9 @@ public class DialogTest {
     assertEquals("---\n"
             + "**Dialog**\n"
             + "title\n"
-            + "body\n"
-            + "footer\n"
-            + "---\n",
+            + "\nbody\n"
+            + "\nfooter\n"
+            + "\n---\n",
         context.getMarkdown());
   }
 
@@ -354,8 +354,8 @@ public class DialogTest {
     assertEquals("---\n"
             + "**Dialog**\n"
             + "**A title**\n"
-            + "body\n"
-            + "---\n",
+            + "\nbody\n"
+            + "\n---\n",
         context.getMarkdown());
   }
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/DivTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/DivTest.java
@@ -1,6 +1,7 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -65,13 +66,13 @@ public class DivTest extends ElementTest {
   }
 
   @Test
-  public void testDivInvaliIconSrc() throws Exception {
+  public void testDivInvalidIconSrc() throws Exception {
     String div = "<messageML><div data-icon-src=\"attr\">txt</div></messageML>";
 
-    expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage(
-        "The attribute \"data-icon-src\" is only allowed if the element class is \"card\".");
-    context.parseMessageML(div, null, MessageML.MESSAGEML_VERSION);
+    InvalidInputException ex =
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML(div, null, MessageML.MESSAGEML_VERSION));
+
+    assertEquals("The attribute \"data-icon-src\" is only allowed if the element class is \"card\".", ex.getMessage());
   }
 
   @Test

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/DivTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/DivTest.java
@@ -1,7 +1,6 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -66,13 +65,13 @@ public class DivTest extends ElementTest {
   }
 
   @Test
-  public void testDivInvalidIconSrc() throws Exception {
+  public void testDivInvaliIconSrc() throws Exception {
     String div = "<messageML><div data-icon-src=\"attr\">txt</div></messageML>";
 
-    InvalidInputException ex =
-        assertThrows(InvalidInputException.class, () -> context.parseMessageML(div, null, MessageML.MESSAGEML_VERSION));
-
-    assertEquals("The attribute \"data-icon-src\" is only allowed if the element class is \"card\".", ex.getMessage());
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "The attribute \"data-icon-src\" is only allowed if the element class is \"card\".");
+    context.parseMessageML(div, null, MessageML.MESSAGEML_VERSION);
   }
 
   @Test

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -71,12 +70,12 @@ public class DatePickerTest extends ElementTest {
         + "---\n";
     String expectedPresentationML = "<div data-format=\"PresentationML\" data-version=\"2"
         + ".0\"><form id=\"datepicker-form\"><input type=\"date\" name=\"date-travel\" value=\"2020-09-15\" "
-        + "placeholder=\"Please pick a date\" min=\"2020-09-01\" max=\"2020-09-29\" "
+        + "placeholder=\"Please pick a date\" min=\"2020-09-01\" max=\"2020-09-29\" required=\"true\" "
         + "data-disabled-date='[{\"type\":\"date\",\"day\":\"2020-09-23\"},{\"type\":\"range\","
         + "\"from\":\"2020-09-18\",\"to\":\"2020-09-20\"},{\"type\":\"weekdays\",\"daysOfWeek\":[0,1]}]' "
         + "data-highlighted-date='[{\"type\":\"date\",\"day\":\"2020-09-24\"},{\"type\":\"range\","
         + "\"from\":\"2020-09-26\",\"to\":\"2020-09-28\"},{\"type\":\"date\",\"day\":\"2020-09-03\"},"
-        + "{\"type\":\"weekdays\",\"daysOfWeek\":[4,6]}]' required=\"true\" "
+        + "{\"type\":\"weekdays\",\"daysOfWeek\":[4,6]}]' "
         + "data-format=\"yyyy-MM-dd\"></input><button type=\"action\" "
         + "name=\"actionName\">Send</button></form></div>";
 
@@ -128,12 +127,12 @@ public class DatePickerTest extends ElementTest {
         + "date</label><span class=\"info-hint\" data-target-id=\"date-picker-%s\" "
         + "data-title=\"This is \\n a hint\"></span><input type=\"date\" name=\"date-travel\" "
         + "value=\"2020-09-15\" placeholder=\"Please pick a date\" min=\"2020-09-01\" "
-        + "max=\"2020-09-29\" data-disabled-date='[{\"type\":\"date\",\"day\":\"2020-09-23\"},"
+        + "max=\"2020-09-29\" required=\"true\" data-disabled-date='[{\"type\":\"date\",\"day\":\"2020-09-23\"},"
         + "{\"type\":\"range\",\"from\":\"2020-09-18\",\"to\":\"2020-09-20\"},{\"type\":\"weekdays\","
         + "\"daysOfWeek\":[0,1]}]' data-highlighted-date='[{\"type\":\"date\",\"day\":"
         + "\"2020-09-24\"},{\"type\":\"range\",\"from\":\"2020-09-26\",\"to\":\"2020-09-28\"},{\"type\":"
         + "\"date\",\"day\":\"2020-09-03\"},{\"type\":\"weekdays\",\"daysOfWeek\":[4,6]}]' "
-        + "required=\"true\" data-format=\"yyyy-MM-dd\" "
+        + "data-format=\"yyyy-MM-dd\" "
         + "id=\"date-picker-%s\"></input></div><button type=\"action\" "
         + "name=\"actionName\">Send</button></form></div>", uniqueLabelId, uniqueLabelId, uniqueLabelId, uniqueLabelId);
 
@@ -185,12 +184,12 @@ public class DatePickerTest extends ElementTest {
             + "date</label><span class=\"info-hint\" data-target-id=\"date-picker-%s\" "
             + "data-title=\"This_is_a_hint\"></span><input type=\"date\" name=\"date-travel\" "
             + "value=\"2020-09-15\" placeholder=\"Please_pick_a_date\" min=\"2020-09-01\" "
-            + "max=\"2020-09-29\" data-disabled-date='[{\"type\":\"date\",\"day\":\"2020-09-23\"},"
+            + "max=\"2020-09-29\" required=\"true\" data-disabled-date='[{\"type\":\"date\",\"day\":\"2020-09-23\"},"
             + "{\"type\":\"range\",\"from\":\"2020-09-18\",\"to\":\"2020-09-20\"},{\"type\":\"weekdays\","
             + "\"daysOfWeek\":[0,1]}]' data-highlighted-date='[{\"type\":\"date\",\"day\":"
             + "\"2020-09-24\"},{\"type\":\"range\",\"from\":\"2020-09-26\",\"to\":\"2020-09-28\"},{\"type\":"
             + "\"date\",\"day\":\"2020-09-03\"},{\"type\":\"weekdays\",\"daysOfWeek\":[4,6]}]' "
-            + "required=\"true\" data-format=\"yyyy-MM-dd\" "
+            + "data-format=\"yyyy-MM-dd\" "
             + "id=\"date-picker-%s\"></input></div><button type=\"action\" "
             + "name=\"actionName\">Send</button></form></div>", uniqueLabelId, uniqueLabelId, uniqueLabelId, uniqueLabelId);
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/util/XmlUtils.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/util/XmlUtils.java
@@ -1,0 +1,30 @@
+package org.symphonyoss.symphony.messageml.util;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.bootstrap.DOMImplementationRegistry;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSSerializer;
+import org.xml.sax.InputSource;
+
+import java.io.StringReader;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class XmlUtils {
+
+  public static String prettyXml(String input) {
+    try {
+      final InputSource src = new InputSource(new StringReader(input));
+      final Node document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(src).getDocumentElement();
+      final DOMImplementationRegistry registry = DOMImplementationRegistry.newInstance();
+      final DOMImplementationLS impl = (DOMImplementationLS) registry.getDOMImplementation("LS");
+      final LSSerializer writer = impl.createLSSerializer();
+      writer.getDomConfig().setParameter("format-pretty-print", Boolean.TRUE);
+      writer.getDomConfig().setParameter("xml-declaration", false);
+      return writer.writeToString(document);
+    } catch (Exception ex) {
+      System.err.printf("Cannot prettify XML input: %s", ex.getMessage());
+      return input;
+    }
+  }
+}

--- a/src/test/resources/examples/action-dialog.xml
+++ b/src/test/resources/examples/action-dialog.xml
@@ -1,0 +1,58 @@
+<messageML>
+    <form id="wrapping_dialog">
+        <h4>First part: form wrapping a dialog</h4>
+        <p>Here is the beginning of the form containing the dialog hiding some large text</p>
+        <text-field name="input1" label="This is an interactive Element in the form but outside of the dialog" />
+        <p>Please click on the following button in order to open the dialog and see the hidden information</p>
+        <ui-action action="open-dialog" target-id="dialog_in_form">
+            <button class="secondary">Open the dialog contained in the form</button>
+        </ui-action>
+        <text-field name="input2" label="This is an interactive Element in the form but outside of the dialog" />
+        <button name="wrapping_dialog">Submit Button of the Form</button>
+        <dialog id="dialog_in_form">
+            <title>
+                This is a title
+            </title>
+            <body>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam congue viverra interdum. Integer quam odio, gravida ultricies pharetra ac, tempor eget leo. Duis vitae arcu sed turpis faucibus feugiat a at ipsum. Nulla facilisi. Phasellus egestas, leo et malesuada porttitor, felis turpis viverra tortor, quis suscipit orci nibh at augue. Curabitur erat libero, accumsan vitae ipsum eleifend, tincidunt bibendum purus. Curabitur ultricies lorem tincidunt rutrum viverra. Sed mattis dui at suscipit auctor. In rutrum neque urna, vitae lacinia turpis blandit eget. Nullam eu dignissim purus. Sed ut ante lorem. Duis quis mi nec enim imperdiet consectetur. Phasellus aliquet accumsan ipsum non ullamcorper.<br/><br/>
+                Praesent convallis odio tortor, sit amet vulputate nulla tincidunt vitae. Donec ultrices eros suscipit mauris condimentum iaculis. Ut posuere finibus quam a consequat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nam aliquet dapibus vehicula. Nunc vel lectus congue, finibus felis ut, laoreet est. Maecenas eleifend gravida metus, nec viverra mi egestas eu. Pellentesque scelerisque mattis nibh, eu condimentum nulla finibus ut.<br/><br/>
+                Ut dignissim varius libero ac volutpat. Sed hendrerit nec libero ut ullamcorper. Nunc et risus sed purus luctus faucibus nec eu est. Praesent id justo ante. Sed sed enim velit. Ut ac mauris magna. Fusce bibendum ullamcorper diam quis semper. Aenean mattis auctor ultricies. Mauris dui enim, vehicula sit amet finibus non, consectetur eu ante. Fusce at mi a ipsum gravida rhoncus.<br/><br/>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam congue viverra interdum. Integer quam odio, gravida ultricies pharetra ac, tempor eget leo. Duis vitae arcu sed turpis faucibus feugiat a at ipsum. Nulla facilisi. Phasellus egestas, leo et malesuada porttitor, felis turpis viverra tortor, quis suscipit orci nibh at augue. Curabitur erat libero, accumsan vitae ipsum eleifend, tincidunt bibendum purus. Curabitur ultricies lorem tincidunt rutrum viverra. Sed mattis dui at suscipit auctor. In rutrum neque urna, vitae lacinia turpis blandit eget. Nullam eu dignissim purus. Sed ut ante lorem. Duis quis mi nec enim imperdiet consectetur. Phasellus aliquet accumsan ipsum non ullamcorper.<br/><br/>
+                Praesent convallis odio tortor, sit amet vulputate nulla tincidunt vitae. Donec ultrices eros suscipit mauris condimentum iaculis. Ut posuere finibus quam a consequat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nam aliquet dapibus vehicula. Nunc vel lectus congue, finibus felis ut, laoreet est. Maecenas eleifend gravida metus, nec viverra mi egestas eu. Pellentesque scelerisque mattis nibh, eu condimentum nulla finibus ut.<br/><br/>
+                Ut dignissim varius libero ac volutpat. Sed hendrerit nec libero ut ullamcorper. Nunc et risus sed purus luctus faucibus nec eu est. Praesent id justo ante. Sed sed enim velit. Ut ac mauris magna. Fusce bibendum ullamcorper diam quis semper. Aenean mattis auctor ultricies. Mauris dui enim, vehicula sit amet finibus non, consectetur eu ante. Fusce at mi a ipsum gravida rhoncus.
+            </body>
+            <footer>
+                This is a footer
+                <button name="cancel1" type="cancel">Close</button>
+            </footer>
+        </dialog>
+    </form>
+    <br/>
+    <br/>
+    <h4>Second part: message with a dialog hiding a form</h4>
+    <p>Here is the beginning of the message containing the dialog hiding some large form</p>
+    <dialog id="dialog_containing_form" width="large">
+        <form id="wrapped_in_dialog">
+            <title>
+                This is a title
+            </title>
+            <body>
+                <text-field name="input3" label="This is an interactive Element in the form which is contained in the dialog" />
+                <textarea name="textarea" label="Other interactive Element in the dialog" />
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam congue viverra interdum. Integer quam odio, gravida ultricies pharetra ac, tempor eget leo. Duis vitae arcu sed turpis faucibus feugiat a at ipsum. Nulla facilisi. Phasellus egestas, leo et malesuada porttitor, felis turpis viverra tortor, quis suscipit orci nibh at augue. Curabitur erat libero, accumsan vitae ipsum eleifend, tincidunt bibendum purus. Curabitur ultricies lorem tincidunt rutrum viverra. Sed mattis dui at suscipit auctor. In rutrum neque urna, vitae lacinia turpis blandit eget. Nullam eu dignissim purus. Sed ut ante lorem. Duis quis mi nec enim imperdiet consectetur. Phasellus aliquet accumsan ipsum non ullamcorper.<br/><br/>
+                Praesent convallis odio tortor, sit amet vulputate nulla tincidunt vitae. Donec ultrices eros suscipit mauris condimentum iaculis. Ut posuere finibus quam a consequat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nam aliquet dapibus vehicula. Nunc vel lectus congue, finibus felis ut, laoreet est. Maecenas eleifend gravida metus, nec viverra mi egestas eu. Pellentesque scelerisque mattis nibh, eu condimentum nulla finibus ut.<br/><br/>
+                Ut dignissim varius libero ac volutpat. Sed hendrerit nec libero ut ullamcorper. Nunc et risus sed purus luctus faucibus nec eu est. Praesent id justo ante. Sed sed enim velit. Ut ac mauris magna. Fusce bibendum ullamcorper diam quis semper. Aenean mattis auctor ultricies. Mauris dui enim, vehicula sit amet finibus non, consectetur eu ante. Fusce at mi a ipsum gravida rhoncus.<br/><br/>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam congue viverra interdum. Integer quam odio, gravida ultricies pharetra ac, tempor eget leo. Duis vitae arcu sed turpis faucibus feugiat a at ipsum. Nulla facilisi. Phasellus egestas, leo et malesuada porttitor, felis turpis viverra tortor, quis suscipit orci nibh at augue. Curabitur erat libero, accumsan vitae ipsum eleifend, tincidunt bibendum purus. Curabitur ultricies lorem tincidunt rutrum viverra. Sed mattis dui at suscipit auctor. In rutrum neque urna, vitae lacinia turpis blandit eget. Nullam eu dignissim purus. Sed ut ante lorem. Duis quis mi nec enim imperdiet consectetur. Phasellus aliquet accumsan ipsum non ullamcorper.<br/><br/>
+                Praesent convallis odio tortor, sit amet vulputate nulla tincidunt vitae. Donec ultrices eros suscipit mauris condimentum iaculis. Ut posuere finibus quam a consequat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nam aliquet dapibus vehicula. Nunc vel lectus congue, finibus felis ut, laoreet est. Maecenas eleifend gravida metus, nec viverra mi egestas eu. Pellentesque scelerisque mattis nibh, eu condimentum nulla finibus ut.<br/><br/>
+                Ut dignissim varius libero ac volutpat. Sed hendrerit nec libero ut ullamcorper. Nunc et risus sed purus luctus faucibus nec eu est. Praesent id justo ante. Sed sed enim velit. Ut ac mauris magna. Fusce bibendum ullamcorper diam quis semper. Aenean mattis auctor ultricies. Mauris dui enim, vehicula sit amet finibus non, consectetur eu ante. Fusce at mi a ipsum gravida rhoncus.
+            </body>
+            <footer>
+                <button name="cancel2" type="cancel">Close</button>
+                <button name="wrapping_dialog">Submit Button of the Form</button>
+            </footer>
+        </form>
+    </dialog>
+    <ui-action action="open-dialog" target-id="dialog_containing_form">
+        <button class="secondary">Open the dialog containing the form</button>
+    </ui-action>
+</messageML>

--- a/src/test/resources/examples/action.xml
+++ b/src/test/resources/examples/action.xml
@@ -1,6 +1,14 @@
 <messageML>
-    <ui-action action='open-im' stream-id='rKiuGRoGDTrPtpHSIgmUgH///oVFs7kzdA=='><button>Stream</button></ui-action>
-    <ui-action action='open-im' trigger='click' user-ids='[13056700583037]'><button class='secondary'>User A</button></ui-action>
-    <ui-action action='open-im' trigger='click' user-ids='[13056700583037,13056700583039]'><button class='tertiary'>List of Users</button></ui-action>
-    <ui-action action='open-im' trigger='click' stream-id='rKiuGRoGDTrPtpHSIgmUgH///oVFs7kzdA==' side-by-side='false'><button class='destructive'>Replace current chat</button></ui-action>
+    <ui-action action='open-im' stream-id='rKiuGRoGDTrPtpHSIgmUgH///oVFs7kzdA=='>
+        <button>Stream</button>
+    </ui-action>
+    <ui-action action='open-im' trigger='click' user-ids='[13056700583037]'>
+        <button class='secondary'>User A</button>
+    </ui-action>
+    <ui-action action='open-im' trigger='click' user-ids='[13056700583037,13056700583039]'>
+        <button class='tertiary'>List of Users</button>
+    </ui-action>
+    <ui-action action='open-im' trigger='click' stream-id='rKiuGRoGDTrPtpHSIgmUgH///oVFs7kzdA==' side-by-side='false'>
+        <button class='destructive'>Replace current chat</button>
+    </ui-action>
 </messageML>

--- a/src/test/resources/examples/action.xml
+++ b/src/test/resources/examples/action.xml
@@ -1,0 +1,6 @@
+<messageML>
+    <ui-action action='open-im' stream-id='rKiuGRoGDTrPtpHSIgmUgH///oVFs7kzdA=='><button>Stream</button></ui-action>
+    <ui-action action='open-im' trigger='click' user-ids='[13056700583037]'><button class='secondary'>User A</button></ui-action>
+    <ui-action action='open-im' trigger='click' user-ids='[13056700583037,13056700583039]'><button class='tertiary'>List of Users</button></ui-action>
+    <ui-action action='open-im' trigger='click' stream-id='rKiuGRoGDTrPtpHSIgmUgH///oVFs7kzdA==' side-by-side='false'><button class='destructive'>Replace current chat</button></ui-action>
+</messageML>

--- a/src/test/resources/examples/card-expandable.xml
+++ b/src/test/resources/examples/card-expandable.xml
@@ -1,0 +1,9 @@
+<messageML>
+    <expandable-card state="expanded">
+        <header>Card Header. Always visible.</header>
+        <body variant="default">
+            Card Body. User must click to view it (when the card is sent collapsed/cropped).
+            [it may contain a title, a paragraph, other elements for e.g. data bar and action bar]
+        </body>
+    </expandable-card>
+</messageML>

--- a/src/test/resources/examples/card.xml
+++ b/src/test/resources/examples/card.xml
@@ -1,0 +1,8 @@
+<messageML>
+    <br/>
+    <h2>Cards</h2>
+    <card accent="tempo-bg-color--blue" iconSrc="./images/favicon.png">
+        <header>Card Header. Always visible.</header>
+        <body>Card Body. User must click to view it.</body>
+    </card>
+</messageML>

--- a/src/test/resources/examples/code.xml
+++ b/src/test/resources/examples/code.xml
@@ -1,0 +1,9 @@
+<messageML>
+    <h2>Code Block</h2>
+    <code>
+        public void someMethod(String someAttribute) {
+            System.out.println("This is a code block");
+            System.out.println("Value of Attribute:" + someAttribute);
+        }
+    </code>
+</messageML>

--- a/src/test/resources/examples/complex.json
+++ b/src/test/resources/examples/complex.json
@@ -1,0 +1,61 @@
+{
+    "jiraIssue" : {
+        "type" : "com.symphony.integration.jira.event.v2.state",
+        "version" : "1.0",
+        "accent" : "green",
+        "baseUrl" : "https://jira.atlassian.com",
+        "tokenColor" : "blue",
+        "icon" : {
+            "type" : "com.symphony.integration.icon",
+            "version" : "1.0",
+            "url" : "https://renderer-tool.app.symphony.com/images/jira_icon.png"
+        },
+        "user" : {
+            "type" : "com.symphony.integration.user",
+            "version" : "1.0",
+            "id" : "123456",
+            "emailAddress" : "test@symphony.com",
+            "username" : "integrationuser",
+            "displayName" : "User 3"
+        },
+        "issue" : {
+            "type" : "com.symphony.integration.jira.issue",
+            "version" : "1.0",
+            "key" : "TICKET-25",
+            "url" : "https://jira.atlassian.com/browse/TICKET-25",
+            "subject" : "Ticket name",
+            "description" : "Description of a Jira Ticket",
+            "status" : "TO DO",
+            "action" : "Created",
+            "issueType" : {
+                "type" : "com.symphony.integration.jira.issueType",
+                "version" : "1.0",
+                "name" : "Story",
+                "iconUrl" : "https://jira.atlassian.com/secure/viewavatar?size=xsmall&amp;avatarId=51504&amp;avatarType=issuetype"
+            },
+            "priority" : {
+                "type" : "com.symphony.integration.jira.priority",
+                "version" : "1.0",
+                "iconUrl" : "https://jira.atlassian.com/images/icons/priorities/highest.svg",
+                "name" : "Highest"
+            },
+            "assignee" : {
+                "type" : "com.symphony.integration.user",
+                "version" : "1.0",
+                "id" : "123456",
+                "emailAddress" : "test@symphony.com",
+                "username" : "integrationuser",
+                "displayName" : "Mock user"
+            },
+            "labels" : [ {
+                "type" : "com.symphony.integration.jira.label",
+                "version" : "1.0",
+                "text" : "production"
+            }, {
+                "type" : "com.symphony.integration.jira.label",
+                "version" : "1.0",
+                "text" : "rc"
+            } ]
+        }
+    }
+}

--- a/src/test/resources/examples/complex.xml
+++ b/src/test/resources/examples/complex.xml
@@ -1,0 +1,66 @@
+<messageML>
+    <br/>
+    <h2>Complex MessageML + EntityJSON</h2>
+    <div class="entity" data-entity-id="jiraIssue">
+        <card class="barStyle" accent="tempo-bg-color--${entity['jiraIssue'].accent!'gray'}" iconSrc="${entity['jiraIssue'].icon.url}">
+        <header>
+            <div>
+                <img src="${entity['jiraIssue'].issue.priority.iconUrl}" class="icon"/>
+                <a class="tempo-text-color--link" href="${entity['jiraIssue'].issue.url}">
+                    ${entity['jiraIssue'].issue.key}
+                </a>
+                <span class="tempo-text-color--normal">${entity['jiraIssue'].issue.subject} -</span>
+                <span>${entity['jiraIssue'].user.displayName}</span>
+                <span class="tempo-text-color--green">${entity['jiraIssue'].issue.action}</span>
+            </div>
+        </header>
+        <body>
+        <div>
+            <div>
+                <#if (entity['jiraIssue'].issue.description)??>
+                <span class="tempo-text-color--secondary">Description:</span>
+                <span class="tempo-text-color--normal">${entity['jiraIssue'].issue.description}</span>
+            </#if>
+
+            <br/>
+            <span class="tempo-text-color--secondary">Assignee:</span>
+            <#if (entity['jiraIssue'].issue.assignee.id)??>
+            <mention email="${entity['jiraIssue'].issue.assignee.emailAddress}"/>
+            <#else>
+            <span class="tempo-text-color--normal">${entity['jiraIssue'].issue.assignee.displayName}</span>
+        </#if>
+    </div>
+    <hr/>
+    <div>
+        <span class="tempo-text-color--secondary">Type:</span>
+        <img src="${entity['jiraIssue'].issue.issueType.iconUrl}" class="icon"/>
+        <span class="tempo-text-color--normal">${entity['jiraIssue'].issue.issueType.name}</span>
+
+        <span class="tempo-text-color--secondary">&#160;&#160;&#160;Priority:</span>
+        <img src="${entity['jiraIssue'].issue.priority.iconUrl}" class="icon"/>
+        <span class="tempo-text-color--normal">${entity['jiraIssue'].issue.priority.name}</span>
+
+
+        <#if (entity['jiraIssue'].issue.epic)??>
+        <span class="tempo-text-color--secondary">&#160;&#160;&#160;Epic:</span>
+        <a href="${entity['jiraIssue'].issue.epic.link}">${entity['jiraIssue'].issue.epic.name}</a>
+    </#if>
+
+    <span class="tempo-text-color--secondary">&#160;&#160;&#160;Status:</span>
+    <span class="tempo-bg-color--${entity['jiraIssue'].tokenColor} tempo-text-color--white tempo-token">
+        ${entity['jiraIssue'].issue.status?upper_case}
+    </span>
+
+
+    <#if (entity['jiraIssue'].issue.labels)??>
+    <span class="tempo-text-color--secondary">&#160;&#160;&#160;Labels:</span>
+    <#list entity['jiraIssue'].issue.labels as label>
+    <span class="hashTag">#${label.text}</span>
+</#list>
+        </#if>
+        </div>
+        </div>
+        </body>
+        </card>
+        </div>
+        </messageML>

--- a/src/test/resources/examples/date-picker.xml
+++ b/src/test/resources/examples/date-picker.xml
@@ -1,13 +1,14 @@
 <messageML>
     <form id="form_id">
         <h2>date-pickers</h2>
-        <date-picker name="init" value="2020-08-28"></date-picker>
+        <date-picker name="init" value="2020-08-28" required="true"></date-picker>
         <date-picker name="placeholder" placeholder="Only Placeholder: MM-DD-YYYY"></date-picker>
-        <date-picker name="label" label="My Label"></date-picker>
+        <date-picker name="label" label="My Label" required="true"></date-picker>
         <date-picker name="tooltip" label="With Tooltip" title="My Tooltip\n With a second line"></date-picker>
         <date-picker name="req" required="true" label="Required"></date-picker>
         <date-picker name="format" label="Other Format" format="dd/MM/yyyy"></date-picker>
-        <date-picker name="rules" label="With disabled and highlighted dates" min="2021-01-04" max="2021-01-27"
+        <date-picker name="rules" label="With disabled and highlighted dates"
+                     min="2021-01-04" max="2021-01-27" required="true"
                      disabled-date='[{"from": "2021-01-13", "to": "2021-01-15"}, {"from": "2021-01-19", "to": "2021-01-21"}, {"day": "2021-01-06"}, {"daysOfWeek": [0,6]}]'
                      highlighted-date='[{"day": "2021-01-05"}, {"day": "2021-01-26"}]'/>
         <button name="date-picker">Submit</button>

--- a/src/test/resources/examples/date-picker.xml
+++ b/src/test/resources/examples/date-picker.xml
@@ -1,0 +1,15 @@
+<messageML>
+    <form id="form_id">
+        <h2>date-pickers</h2>
+        <date-picker name="init" value="2020-08-28"></date-picker>
+        <date-picker name="placeholder" placeholder="Only Placeholder: MM-DD-YYYY"></date-picker>
+        <date-picker name="label" label="My Label"></date-picker>
+        <date-picker name="tooltip" label="With Tooltip" title="My Tooltip\n With a second line"></date-picker>
+        <date-picker name="req" required="true" label="Required"></date-picker>
+        <date-picker name="format" label="Other Format" format="dd/MM/yyyy"></date-picker>
+        <date-picker name="rules" label="With disabled and highlighted dates" min="2021-01-04" max="2021-01-27"
+                     disabled-date='[{"from": "2021-01-13", "to": "2021-01-15"}, {"from": "2021-01-19", "to": "2021-01-21"}, {"day": "2021-01-06"}, {"daysOfWeek": [0,6]}]'
+                     highlighted-date='[{"day": "2021-01-05"}, {"day": "2021-01-26"}]'/>
+        <button name="date-picker">Submit</button>
+    </form>
+</messageML>

--- a/src/test/resources/examples/dialog.xml
+++ b/src/test/resources/examples/dialog.xml
@@ -1,0 +1,9 @@
+<messageML>
+    <dialog id="dialog-id" width="small" state="open">
+        <title>
+            <h2>A title</h2>
+        </title>
+        <body>Some text </body>
+        <footer>Some footer</footer>
+    </dialog>
+</messageML>

--- a/src/test/resources/examples/dialog.xml
+++ b/src/test/resources/examples/dialog.xml
@@ -3,7 +3,7 @@
         <title>
             <h2>A title</h2>
         </title>
-        <body>Some text </body>
-        <footer>Some footer</footer>
+        <body>Some text in the body</body>
+        <footer>Some footer in the footer</footer>
     </dialog>
 </messageML>

--- a/src/test/resources/examples/dropdown.xml
+++ b/src/test/resources/examples/dropdown.xml
@@ -1,0 +1,12 @@
+<messageML>
+    <form id="form_id">
+        <h2>dropdown menus</h2>
+        <select name="init"><option value="opt1">Unselected option 1</option><option value="opt2" selected="true">With selected option</option><option value="opt3">Unselected option 2</option></select>
+        <select name="data-placeholder" data-placeholder="Only data-placeholder"><option value="opt1">Unselected option 1</option><option value="opt2">Unselected option 2</option><option value="opt3">Unselected option 3</option></select>
+        <select name="noreq" data-placeholder="Not required"><option value="opt1">First</option><option value="opt2">Second</option><option value="opt3">Third</option></select>
+        <select name="req" required="true" data-placeholder="Required"><option value="opt1">First</option><option value="opt2">Second</option><option value="opt3">Third</option></select>
+        <select name="label" label="My Label" data-placeholder="With Label"><option value="opt1">Unselected option 1</option><option value="opt2">Unselected option 2</option><option value="opt3">Unselected option 3</option></select>
+        <select name="tooltip" title="My Tooltip\n With a second line" data-placeholder="With Tooltip"><option value="opt1">Unselected option 1</option><option value="opt2">Unselected option 2</option><option value="opt3">Unselected option 3</option></select>
+        <button name="dropdown">Submit</button>
+    </form>
+</messageML>

--- a/src/test/resources/examples/form.xml
+++ b/src/test/resources/examples/form.xml
@@ -1,0 +1,84 @@
+<messageML>
+
+    <h2>Symphony Form Elements</h2>
+
+    <form id="all-elements">
+
+        <div>You can have content inside the form element. This for example is a div inside of it.</div>
+
+        <h5>Checkboxes</h5>
+        <checkbox checked="true" name="fruits" value="orange">Orange</checkbox>
+        <checkbox checked="true" name="fruits" value="apple">Apple</checkbox>
+        <checkbox name="fruits" value="grapes">Grapes</checkbox>
+        <checkbox name="fruits" value="strawberry">Strawberry</checkbox>
+        <checkbox checked="true" name="fruits" value="raspberry">Raspberry</checkbox>
+        <checkbox checked="true" name="fruits" value="grapefruit">Grapefruit</checkbox>
+        <checkbox name="fruits" value="passion">Passion Fruit</checkbox>
+        <checkbox name="fruits" value="peach">Peach</checkbox>
+
+        <br/>
+
+        <checkbox checked="true" name="status" value="off">Off</checkbox>
+        <checkbox name="status">On</checkbox>
+
+        <h5>Radio Buttons</h5>
+        <radio checked="true" name="color" value="blue">Blue</radio>
+        <radio name="color" value="green">Green</radio>
+        <radio name="color" value="yellow">Yellow</radio>
+        <radio name="color" value="red">Red</radio>
+        <radio checked="true" name="color" value="purple">Purple</radio>
+        <radio name="color" value="orange">Orange</radio>
+        <radio name="color" value="pink">Pink</radio>
+        <radio name="color" value="brown">Brown</radio>
+
+        <br/>
+
+        <radio checked="true" name="internetStatus" value="offline">Offline</radio>
+        <radio name="internetStatus">Online (On)</radio>
+
+        <h5>Dropdown Select</h5>
+        <select name="cities">
+            <option selected="true" value="ny">New York</option>
+            <option value="van">Vancouver</option>
+            <option value="par">Paris</option>
+        </select>
+
+        <select data-placeholder="Insert the languages you know..." label="Select your language" name="languages" required="true">
+            <option selected="true" value="en">English</option>
+            <option value="sp">Spanish</option>
+            <option value="pt">Portuguese</option>
+            <option value="fr">French</option>
+            <option value="de">German</option>
+            <option value="it">Italian</option>
+        </select>
+
+        <h5>Person Selector</h5>
+
+        <person-selector name="person-selector" placeholder="Type a person's name"/>
+
+        <h5>Text Fields</h5>
+        <text-field name="name" placeholder="Input your name..." required="true"/>
+        <text-field name="age" placeholder="Text field with a tool tip" title="What's your age?"/>
+
+        <br/>
+
+        <text-field label="Text field with a default value" name="obs" placeholder="Observations here...">No observation.</text-field>
+
+        <h5>Textarea</h5>
+        <textarea name="id" placeholder="What did you think of this?" required="true">No comments.</textarea>
+        <textarea name="comments" maxlength="25" minlength="3">No comments.</textarea>
+
+        <h5>Masked Text Fields</h5>
+        <text-field masked="true" maxlength="25" minlength="3" name="answer" placeholder="Insert answer..." required="true"/>
+        <text-field masked="true" name="hiddenNotes" placeholder="I don't want to tell but..." required="true"/>
+
+        <br/>
+
+        <text-field masked="true" maxlength="100" minlength="3" name="movieEnding" placeholder="What's the movie ending?" required="true">The bad guy was the main character all along.</text-field>
+
+        <h5>Buttons</h5>
+        <button name="send-answers" type="action">Send Answers</button>
+        <button type="reset">Reset Data</button>
+    </form>
+
+</messageML>

--- a/src/test/resources/examples/person.xml
+++ b/src/test/resources/examples/person.xml
@@ -1,0 +1,12 @@
+<messageML>
+    <form id="form_id">
+        <h2>person-selectors</h2>
+        <person-selector name="placeholder" placeholder="My Placeholder"/>
+        <person-selector name="value" label="With default values" value='[12987981109743,12987981109741]' />
+        <person-selector name="noreq" placeholder="Not required"/>
+        <person-selector name="req" required="true" placeholder="Required"/>
+        <person-selector name="label" label="My Label" placeholder="With Label"/>
+        <person-selector name="tooltip" title="My Tooltip\n With a second line" placeholder="With Tooltip"/>
+        <button name="person-selector">Submit</button>
+    </form>
+</messageML>

--- a/src/test/resources/examples/table-select.xml
+++ b/src/test/resources/examples/table-select.xml
@@ -1,0 +1,50 @@
+<messageML>
+    <form id="example">
+        <table>
+            <thead>
+                <tr>
+                    <td>Select</td>
+                    <td>H1</td>
+                    <td>H2</td>
+                    <td>H3</td>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>
+                        <button type="action" name="tablesel-row-1">SELECT</button>
+                    </td>
+                    <td>A1</td>
+                    <td>B1</td>
+                    <td>C1</td>
+                </tr>
+                <tr>
+                    <td>
+                        <button type="action" name="tablesel-row-2">SELECT</button>
+                    </td>
+                    <td>A2</td>
+                    <td>B2</td>
+                    <td>C2</td>
+                </tr>
+                <tr>
+                    <td>
+                        <button type="action" name="tablesel-row-3">SELECT</button>
+                    </td>
+                    <td>A3</td>
+                    <td>B3</td>
+                    <td>C3</td>
+                </tr>
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td>
+                        <button type="action" name="tablesel-footer">SELECT</button>
+                    </td>
+                    <td>F1</td>
+                    <td>F2</td>
+                    <td>F3</td>
+                </tr>
+            </tfoot>
+        </table>
+    </form>
+</messageML>

--- a/src/test/resources/examples/table.xml
+++ b/src/test/resources/examples/table.xml
@@ -1,0 +1,39 @@
+<messageML>
+    <h2>Table</h2>
+    <table>
+        <thead>
+            <tr>
+                <td>Header 1</td>
+                <td>Header 2</td>
+                <td>Header 3</td>
+                <td>Header 4</td>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td colspan="2">Content 1.1 with colspan</td>
+                <td>Content 3.1</td>
+                <td>Content 4.1</td>
+            </tr>
+            <tr>
+                <td rowspan="2">Content 1.2 with rowspan</td>
+                <td>Content 2.2</td>
+                <td>Content 3.2</td>
+                <td>Content 4.2</td>
+            </tr>
+            <tr>
+                <td>Content 2.3</td>
+                <td>Content 3.3</td>
+                <td>Content 4.3</td>
+            </tr>
+        </tbody>
+        <tfoot>
+            <tr>
+                <td>Footer 1</td>
+                <td>Footer 2</td>
+                <td>Footer 3</td>
+                <td>Footer 4</td>
+            </tr>
+        </tfoot>
+    </table>
+</messageML>

--- a/src/test/resources/examples/text.xml
+++ b/src/test/resources/examples/text.xml
@@ -1,0 +1,33 @@
+<messageML>
+
+    <h2>Text-level formatting and semantics</h2>
+
+    <hr/>
+
+    <a href="http://www.symphony.com">This is a link to Symphony's Website</a>
+
+    <br/>
+    Here goes a line break using the "br" tag:
+
+    <br/>
+
+    <b>this is bold text</b>
+    ,
+
+    <i>now it's italic</i>
+
+    <br/>
+
+    <span class="tempo-text-color--green">
+        This is a span with the "class" attribute. See, all the text inside the tag is green.
+    </span>
+
+    <br/>
+
+    <span style="border: 1px solid black;">
+        This is a span with the "style" attribute. See documentation for supported styles.
+    </span>
+
+    <pre>This is preformatted text</pre>
+
+</messageML>

--- a/src/test/resources/examples/time-picker.xml
+++ b/src/test/resources/examples/time-picker.xml
@@ -1,0 +1,16 @@
+<messageML>
+    <form id="form_id">
+        <h2>time-pickers</h2>
+        <time-picker name="init" label="With default value" value="13:51:06" />
+        <time-picker name="placeholder" placeholder="Only Placeholder..." />
+        <time-picker name="label" label="My Label" />
+        <time-picker name="tooltip" label="With Tooltip" title="My Tooltip\n With a second line" />
+        <time-picker name="noreq" placeholder="Not required" />
+        <time-picker name="req" required="true" placeholder="Required" />
+        <time-picker name="format" label="Other Format" format="hh:mm a" />
+        <time-picker name="step" label="With a customed time-step" step="600" />
+        <time-picker name="strict_step" label="Restricting values to the time-step defined" strict="true" />
+        <time-picker name="rules" label="With Disabled values" min="08:00:00" max="17:00:00" disabled-time='[{"from": "12:00:00", "to": "14:00:00"}, {"time": "15:00:00"}]' />
+        <button name="time-picker">Submit</button>
+    </form>
+</messageML>

--- a/src/test/resources/examples/time-zone.xml
+++ b/src/test/resources/examples/time-zone.xml
@@ -1,0 +1,21 @@
+<messageML>
+    <form id="example">
+        <timezone-picker
+                name="timezone-name"
+                value="America/New_York"
+                placeholder="Please select a timezone"
+                required="true"
+                disabled-timezone='["America/Detroit", "America/Los_Angeles"]'
+        />
+
+        <timezone-picker
+                name="timezone-name"
+                value="America/New_York"
+                label="Field label" title="This is a \n hint"
+                placeholder="Please select a timezone"
+                required="true"
+                disabled-timezone='["America/Detroit", "America/Los_Angeles"]'
+        />
+        <button name="send-answers" type="action">Submit</button>
+    </form>
+</messageML>


### PR DESCRIPTION
`MessageML` is a superset of `PresentationML`. It means that any `PresentationML` message should be parseable as valid `MessageML`. 

We noticed that we've missed this rule when implementing recent `MessageML` capabilities such as [`<ui-action>`](https://docs.developers.symphony.com/building-bots-on-symphony/messages/overview-of-messageml/ui-action-for-your-bots-ui-extensibility), [`<dialog>`](https://docs.developers.symphony.com/building-bots-on-symphony/messages/overview-of-messageml/ui-action-for-your-bots-ui-extensibility/dialog) or [`<time-picker>`](https://docs.developers.symphony.com/building-bots-on-symphony/messages/overview-of-messageml/symphony-elements-1/time-picker) elements. 

Most of the examples have been taken from our [Developer Documentation](https://docs.developers.symphony.com/building-bots-on-symphony/messages/overview-of-messageml) or our [PresentationML Live Renderer Tool](https://renderer-tool.app.symphony.com/).  