### PR TITLE
Increased nexus stagingProgressTimeoutMinutes to 10 minutes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
                             <serverId>ossrh-distro</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
Default value was 5 minutes, [sonatype](https://status.maven.org) seems to be overloaded (#log4shell), hopefully increasing it to 10 minutes will allow us to release the library. 