### PR TITLE
MessageML tag accepts xmlns attribute

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/MessageML.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/MessageML.java
@@ -22,8 +22,11 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 
+import static org.symphonyoss.symphony.messageml.elements.UIAction.TARGET_ID;
+
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.StringUtils;
 import org.commonmark.node.Document;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
@@ -32,9 +35,6 @@ import org.symphonyoss.symphony.messageml.util.XmlPrintStream;
 import org.w3c.dom.Node;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.symphonyoss.symphony.messageml.elements.UIAction.TARGET_ID;
 
 
 /**
@@ -49,13 +49,16 @@ public class MessageML extends Element {
 
   public static final String MESSAGEML_VERSION = "2.0";
   public static final String MESSAGEML_TAG = "messageML";
+  public static final String MESSAGEML_XMLNS = "https://finos.org/messageml";
   public static final String PRESENTATIONML_TAG = "div";
   private static final String ATTR_FORMAT = "data-format";
   private static final String ATTR_VERSION = "data-version";
+  private static final String ATTR_XMLNS = "xmlns";
   private static final String PRESENTATIONML_FORMAT = "PresentationML";
 
   private String version;
   private boolean chime;
+  private String xmlns;
 
   public MessageML(FormatEnum format, String version) {
     super(null, MESSAGEML_TAG, format);
@@ -63,8 +66,7 @@ public class MessageML extends Element {
   }
 
   @Override
-  protected void buildAttribute(MessageMLParser parser,
-      Node item) throws InvalidInputException {
+  protected void buildAttribute(MessageMLParser parser, Node item) throws InvalidInputException {
     if (getFormat() == FormatEnum.PRESENTATIONML) {
       switch (item.getNodeName()) {
         case ATTR_FORMAT:
@@ -79,7 +81,14 @@ public class MessageML extends Element {
           super.buildAttribute(parser, item);
       }
     } else {
-      super.buildAttribute(parser, item);
+      switch (item.getNodeName()) {
+        case ATTR_XMLNS:
+          this.xmlns = getStringAttribute(item);
+          break;
+
+        default:
+          super.buildAttribute(parser, item);
+      }
     }
   }
 
@@ -122,6 +131,10 @@ public class MessageML extends Element {
     if (format == FormatEnum.MESSAGEML) {
 
       assertNoAttributes();
+
+      if (StringUtils.isNotEmpty(this.xmlns) && !MESSAGEML_XMLNS.equals(this.xmlns)) {
+        throw new InvalidInputException("Invalid namespace \"%s\". Only \"%s\" is allowed.", this.xmlns, MESSAGEML_XMLNS);
+      }
 
     } else if (format == FormatEnum.PRESENTATIONML) {
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/MessageML.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/MessageML.java
@@ -26,7 +26,6 @@ import static org.symphonyoss.symphony.messageml.elements.UIAction.TARGET_ID;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.lang3.StringUtils;
 import org.commonmark.node.Document;
 import org.symphonyoss.symphony.messageml.MessageMLContext;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
@@ -131,10 +130,6 @@ public class MessageML extends Element {
     if (format == FormatEnum.MESSAGEML) {
 
       assertNoAttributes();
-
-      if (StringUtils.isNotEmpty(this.xmlns) && !MESSAGEML_XMLNS.equals(this.xmlns)) {
-        throw new InvalidInputException("Invalid namespace \"%s\". Only \"%s\" is allowed.", this.xmlns, MESSAGEML_XMLNS);
-      }
 
     } else if (format == FormatEnum.PRESENTATIONML) {
 

--- a/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
@@ -19,7 +19,6 @@ package org.symphonyoss.symphony.messageml;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -1321,14 +1320,6 @@ public class MessageMLContextTest {
     final String message = "<messageML xmlns=\"https://finos.org/messageml\">hello</messageML>";
     context.parseMessageML(message, null, MessageML.MESSAGEML_VERSION);
     // nothing should be thrown
-  }
-
-  @Test
-  public void testParseMessageMLWithWrongXmlns() throws Exception {
-    final String message = "<messageML xmlns=\"https://domain.com\">hello</messageML>";
-    InvalidInputException ex = assertThrows(InvalidInputException.class,
-        () -> context.parseMessageML(message, null, MessageML.MESSAGEML_VERSION));
-    assertEquals("Invalid namespace \"https://domain.com\". Only \"https://finos.org/messageml\" is allowed.", ex.getMessage());
   }
 
   private String getPayload(String filename) throws IOException {

--- a/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
@@ -19,6 +19,7 @@ package org.symphonyoss.symphony.messageml;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -1313,6 +1314,21 @@ public class MessageMLContextTest {
     assertEquals("Hashtag count", 2, hashtags.size());
     assertEquals("Label count", 3, labels.size());
 
+  }
+
+  @Test
+  public void testParseMessageMLWithXmlns() throws Exception {
+    final String message = "<messageML xmlns=\"https://finos.org/messageml\">hello</messageML>";
+    context.parseMessageML(message, null, MessageML.MESSAGEML_VERSION);
+    // nothing should be thrown
+  }
+
+  @Test
+  public void testParseMessageMLWithWrongXmlns() throws Exception {
+    final String message = "<messageML xmlns=\"https://domain.com\">hello</messageML>";
+    InvalidInputException ex = assertThrows(InvalidInputException.class,
+        () -> context.parseMessageML(message, null, MessageML.MESSAGEML_VERSION));
+    assertEquals("Invalid namespace \"https://domain.com\". Only \"https://finos.org/messageml\" is allowed.", ex.getMessage());
   }
 
   private String getPayload(String filename) throws IOException {


### PR DESCRIPTION
As a future potential improvement, we'd introduce a XML Schema for MessageML format. We would then need to accept messages like: 
```xml
<messageML xmlns="https://finos.org/messageml">
  <h1>Hello, World!</h1>
</messageML>
```
Here we make sure that we at least support the `xmlns` attribute as earlier as possible, waiting for all Agents to be updated until we really release MessageML XML Schema. 