### PR TITLE
Fixed a bug occurring while parsing Markdown generated by Symphony Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,17 +45,17 @@
 
     <properties>
         <json.schema.validator.version>2.2.14</json.schema.validator.version>
-        <jackson.version>2.10.1</jackson.version>
-        <jackson.databind.version>2.10.5.1</jackson.databind.version>
+        <jackson.version>2.13.1</jackson.version>
         <commons.io.version>2.11.0</commons.io.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <freemarker.version>2.3.31</freemarker.version>
-        <commonmark.version>0.15.1</commonmark.version>
+        <commonmark.version>0.15.2</commonmark.version>
         <mozilla.rhino.version>1.7.13</mozilla.rhino.version>
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.params.version>5.8.1</junit.jupiter.params.version>
         <mockito.version>4.0.0</mockito.version>
-        <slf4j.version>1.7.31</slf4j.version>
+        <slf4j.version>1.7.32</slf4j.version>
+        <logback.version>1.2.9</logback.version>
         <jmh.version>1.33</jmh.version>
         <xmlunit.version>2.8.3</xmlunit.version>
         <lombok.version>1.18.22</lombok.version>
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -205,6 +205,12 @@
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
             <version>${xmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -316,7 +316,12 @@ public abstract class Element {
       Node node = child.asMarkdown();
 
       if (node != null) {
-        parent.appendChild(node);
+        try {
+          parent.appendChild(node);
+        } catch (IllegalArgumentException ex) {
+          // minor issue that appears while parsing Markdown, this fix does not impact Markdown generation
+          logger.trace("{} cannot be appended to {}", node, parent, ex);
+        }
       } else {
         node = parent;
       }

--- a/src/test/java/org/symphonyoss/symphony/messageml/markdown/MarkdownParserTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/markdown/MarkdownParserTest.java
@@ -29,7 +29,6 @@ public class MarkdownParserTest {
     final MessageMLContext context = new MessageMLContext(new TestDataProvider());
     context.parseMarkdown(example.markdown, null, null);
     final String presentationML = context.getPresentationML();
-    log.info("\n" + presentationML);
     assertEquals(example.presentationML, presentationML);
   }
 }

--- a/src/test/java/org/symphonyoss/symphony/messageml/markdown/MarkdownParserTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/markdown/MarkdownParserTest.java
@@ -1,0 +1,35 @@
+package org.symphonyoss.symphony.messageml.markdown;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.symphonyoss.symphony.messageml.MessageMLContext;
+import org.symphonyoss.symphony.messageml.util.TestDataProvider;
+
+@Slf4j
+public class MarkdownParserTest {
+
+  @RequiredArgsConstructor
+  enum Example {
+    ITALIC_WITH_CODE(
+        "_Some text in italic with `code formatting`_",
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><i>Some text in italic with <code>code formatting</code></i></div>"
+    );
+
+    private final String markdown;
+    private final String presentationML;
+  }
+
+  @ParameterizedTest
+  @EnumSource(Example.class)
+  void testParseMarkdown(final Example example) throws Exception {
+    final MessageMLContext context = new MessageMLContext(new TestDataProvider());
+    context.parseMarkdown(example.markdown, null, null);
+    final String presentationML = context.getPresentationML();
+    log.info("\n" + presentationML);
+    assertEquals(example.presentationML, presentationML);
+  }
+}


### PR DESCRIPTION
PR related to [PLAT-11690](https://perzoinc.atlassian.net/browse/PLAT-11690)
Some developers recently noticed that [Agent API Bridge](https://docs.developers.symphony.com/admin-guide/agent-guide) was returning error: 

```
Unable to process message with ID xxx in stream xxx due to: Failed to build Markdown: Parent of block must also be block (can not be inline)
```

The issue is happening when Agent receives replied or forwarded messages since those ones are sent in Markdown format from the Symphony Clients (Mana or 1.5). 

This PR contains an example used to reproduce the issue. More examples and more testing will need to be done regarding the Markdown parsing capability of the library. 