### PR TITLE
Fixed data-pattern-error-message field erased when the <input> tag is used in MessageML format

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/RegexElement.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/RegexElement.java
@@ -92,6 +92,10 @@ public interface RegexElement {
       presentationAttrs.put(PRESENTATIONML_PATTERN_ERROR_MESSAGE_ATTR, getAttribute(PATTERN_ERROR_MESSAGE_ATTR));
     }
 
+    if (getAttribute(PRESENTATIONML_PATTERN_ERROR_MESSAGE_ATTR) != null) {
+      presentationAttrs.put(PRESENTATIONML_PATTERN_ERROR_MESSAGE_ATTR, getAttribute(PRESENTATIONML_PATTERN_ERROR_MESSAGE_ATTR));
+    }
+
     return presentationAttrs;
   }
 
@@ -101,7 +105,7 @@ public interface RegexElement {
    */
   default Map<String, String> getOtherAttributes(){
     Map<String, String> presentationAttrs = new LinkedHashMap<>(getAttributes());
-    ALL_REGEX_ATTRS.stream().forEach(attr -> presentationAttrs.remove(attr));
+    ALL_REGEX_ATTRS.forEach(presentationAttrs::remove);
     return presentationAttrs;
   }
 

--- a/src/test/resources/examples/form.xml
+++ b/src/test/resources/examples/form.xml
@@ -58,7 +58,7 @@
 
         <h5>Text Fields</h5>
         <text-field name="name" placeholder="Input your name..." required="true"/>
-        <text-field name="age" placeholder="Text field with a tool tip" title="What's your age?"/>
+        <text-field name="age" placeholder="Text field with a tool tip" title="What's your age?" pattern="(^[0-9,]+$|^$)" pattern-error-message="Please input numbers."/>
 
         <br/>
 


### PR DESCRIPTION
The `data-pattern-error-message` attribute was erased when converting `<input>` tag from `MessageML` to `PresentationML`. 

Issue fixed and validated via unit tests. 