### PR TITLE
Allowed <pre> tag in a <code> one

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Code.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Code.java
@@ -117,7 +117,7 @@ public class Code extends Element {
     if (StringUtils.isNotEmpty(getAttribute(PML_LANGUAGE_ATTR))) {
       assertAttributeValue(PML_LANGUAGE_ATTR, SUPPORTED_LANGUAGES);
     }
-    assertPhrasingContent();
+    assertPreformattedOrPhrasingContent();
   }
 
   @Override

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -79,6 +79,15 @@ public abstract class Element {
 
   public static final int ID_MAX_LENGTH = 64;
 
+  private static final List<Class<? extends Element>> PHRASING_TYPES =
+      Arrays.asList(TextNode.class, Link.class, Chime.class, Bold.class, Italic.class, Image.class,
+          LineBreak.class, Span.class, Emoji.class, HashTag.class, CashTag.class, Mention.class);
+
+  private static final List<Class<? extends Element>> PHRASING_OR_PREFORMATTED_TYPES = new ArrayList<Class<? extends Element>>() {{
+    addAll(PHRASING_TYPES);
+    add(Preformatted.class);
+  }};
+
   protected FormatEnum format;
   private final Map<String, String> attributes = new LinkedHashMap<>();
   private final List<Element> children = new ArrayList<>();
@@ -638,8 +647,15 @@ public abstract class Element {
    * Check that the element's children are limited to phrasing content.
    */
   void assertPhrasingContent() throws InvalidInputException {
-    assertContentModel(Arrays.asList(TextNode.class, Link.class, Chime.class, Bold.class, Italic.class, Image.class,
-        LineBreak.class, Span.class, Emoji.class, HashTag.class, CashTag.class, Mention.class));
+    assertContentModel(PHRASING_TYPES);
+  }
+
+  /**
+   * Check that the element's children are valid children of a {@link Code} elemet,
+   * i.e. limited to phrasing content or are preformatted elements.
+   */
+  void assertPreformattedOrPhrasingContent() throws InvalidInputException {
+    assertContentModel(PHRASING_OR_PREFORMATTED_TYPES);
   }
 
   /**

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/CodeLanguageTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/CodeLanguageTest.java
@@ -1,8 +1,8 @@
 package org.symphonyoss.symphony.messageml.elements;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -97,5 +97,15 @@ public class CodeLanguageTest {
         () -> this.context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION));
 
     assertEquals("Attribute \"foo\" is not allowed in \"code\"", ex.getMessage());
+  }
+
+  @Test
+  public void testPreformattedInsideCodeIsAllowed() throws Exception {
+    final String input = "<div data-format=\"PresentationML\" data-version=\"2.0\"><code language=\"plaintext\"><pre>Hello</pre></code></div>";
+
+    this.context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    assertEquals("<div data-format=\"PresentationML\" data-version=\"2.0\"><code data-language=\"plaintext\"><pre>Hello</pre></code></div>",
+        this.context.getPresentationML());
   }
 }


### PR DESCRIPTION
Client was generating following PresentationML that was not considered valid by messageml-utils:

```xml
<div data-format="PresentationML" data-version="2.0">
  <code data-language="plaintext"><pre>Hello</pre></code>
</div>
```