### PR TITLE
Adding Bi Items for Custom entities

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -231,7 +231,7 @@ public class MessageMLParser {
    * - increase the total count of entities found in the message
    */
   private void addCustomEntitiesToBiContext(JsonNode entityNode) {
-    entityNode.findValues("type").forEach(entityType -> {
+    entityNode.findValues(Entity.TYPE_FIELD).forEach(entityType -> {
       biContext.updateItemCount(BiFields.ENTITIES.getValue());
       biContext.addItem(new BiItem(BiFields.ENTITY.getValue(),
               Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), entityType.asText())));

--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.bi.BiFields;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
 import org.symphonyoss.symphony.messageml.elements.Bold;
 import org.symphonyoss.symphony.messageml.elements.BulletList;
 import org.symphonyoss.symphony.messageml.elements.Button;
@@ -89,6 +90,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -214,12 +216,26 @@ public class MessageMLParser {
         } else {
           throw new InvalidInputException("Error parsing EntityJSON: provided content is not a JSON object");
         }
+        addCustomEntitiesToBiContext(jsonNode);
       } catch (JsonProcessingException e) {
         throw new InvalidInputException("Error parsing EntityJSON: " + e.getMessage());
       }
     } else {
       this.entityJson = new ObjectNode(JsonNodeFactory.instance);
     }
+  }
+
+  /**
+   * For each custom entity found in the entityJson payload we:
+   * - create a BiItem containing the type of entity found
+   * - increase the total count of entities found in the message
+   */
+  private void addCustomEntitiesToBiContext(JsonNode entityNode) {
+    entityNode.findValues("type").forEach(entityType -> {
+      biContext.updateItemCount(BiFields.ENTITIES.getValue());
+      biContext.addItem(new BiItem(BiFields.ENTITY.getValue(),
+              Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), entityType.asText())));
+    });
   }
 
   /**

--- a/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/MessageMLContextTest.java
@@ -518,7 +518,7 @@ public class MessageMLContextTest {
     List<BiItem> expectedBiItems = getExpectedBiItems();
 
     List<BiItem> biItems = context.getBiContext().getItems();
-    assertEquals(biItems.size(), expectedBiItems.size());
+    assertEquals(expectedBiItems.size(), biItems.size());
     assertTrue(biItems.containsAll(expectedBiItems));
     assertTrue(expectedBiItems.containsAll(biItems));
   }
@@ -535,7 +535,7 @@ public class MessageMLContextTest {
     biItems.add(
         new BiItem(BiFields.MENTIONS.getValue(), Collections.singletonMap(BiFields.COUNT.getValue(), 1)));
     biItems.add(new BiItem(BiFields.CARD.getValue(), Collections.singletonMap(BiFields.COUNT.getValue(), 1)));
-    biItems.add(new BiItem(BiFields.ENTITIES.getValue(), Collections.singletonMap(BiFields.COUNT.getValue(), 1)));
+    biItems.add(new BiItem(BiFields.ENTITIES.getValue(), Collections.singletonMap(BiFields.COUNT.getValue(), 10)));
     biItems.add(
         new BiItem(BiFields.STYLES_CUSTOM.getValue(), Collections.singletonMap(BiFields.COUNT.getValue(), 1)));
     biItems.add(new BiItem(BiFields.STYLES_CLASS_OTHER.getValue(),
@@ -549,6 +549,24 @@ public class MessageMLContextTest {
         Collections.singletonMap(BiFields.COUNT.getValue(), 2984)));
     biItems.add(new BiItem(BiFields.ENTITY.getValue(),
         Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), "com.symphony.user.mention")));
+    biItems.add(new BiItem(BiFields.ENTITY.getValue(),
+            Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), "com.symphony.integration.jira.event.v2.state")));
+    biItems.add(new BiItem(BiFields.ENTITY.getValue(),
+            Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), "com.symphony.integration.user")));
+    biItems.add(new BiItem(BiFields.ENTITY.getValue(),
+            Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), "com.symphony.integration.jira.label")));
+    biItems.add(new BiItem(BiFields.ENTITY.getValue(),
+            Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), "com.symphony.integration.jira.issue")));
+    biItems.add(new BiItem(BiFields.ENTITY.getValue(),
+            Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), "com.symphony.integration.icon")));
+    biItems.add(new BiItem(BiFields.ENTITY.getValue(),
+            Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), "com.symphony.integration.jira.priority")));
+    biItems.add(new BiItem(BiFields.ENTITY.getValue(),
+            Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), "com.symphony.integration.user")));
+    biItems.add(new BiItem(BiFields.ENTITY.getValue(),
+            Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), "com.symphony.integration.jira.issueType")));
+    biItems.add(new BiItem(BiFields.ENTITY.getValue(),
+            Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), "com.symphony.integration.jira.label")));
     return biItems;
   }
 


### PR DESCRIPTION
Goal of this implementation is to add BiItems in the BiContext for custom entities as well.
For each custom entity found in the entityJson payload we
- create a BiItem containing the type of entity found
- increase the total count of entities found in the message

### :white_check_mark: Checklist 
- [x] Unit tests and Javadoc
- [x] Generated PresentationML is valid
> :warning: For this point, please make sure that you have also added a complete example in the 
> `/examples` resources folder. This way the `Mml2Pml2Pml.java` test will ensure that the generated PresentationML is 
> an actual MessageML valid one. 
