### PR TITLE
Removing Option Bi Item and include fields in Dropdown

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/bi/BiFields.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/bi/BiFields.java
@@ -18,7 +18,6 @@ public enum BiFields {
   DATE_SELECTOR("dateselector", BiEventType.MESSAGEML_ELEMENT_SENT),
   PERSON_SELECTOR("personselector", BiEventType.MESSAGEML_ELEMENT_SENT),
   SELECT("dropdownmenu", BiEventType.MESSAGEML_ELEMENT_SENT),
-  OPTION("option", BiEventType.MESSAGEML_ELEMENT_SENT, "0"),
   CHIME("chimes", BiEventType.MESSAGEML_MESSAGE_SENT, "0"),
   CODE("codes", BiEventType.MESSAGEML_MESSAGE_SENT, "0"),
   DIV("divs", BiEventType.MESSAGEML_MESSAGE_SENT, "0"),

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Option.java
@@ -46,17 +46,6 @@ public class Option extends FormElement {
     assertContentModel(Collections.singleton(TextNode.class));
     assertContainsChildOfType(Collections.singleton(TextNode.class));
   }
-
-  @Override
-  public void updateBiContext(BiContext context) {
-    Map<String, Object> attributesMapBi = new HashMap<>();
-
-    attributesMapBi.put(BiFields.OPTIONS_COUNT.getValue(), 1);
-    this.putOneIfPresent(attributesMapBi, BiFields.DEFAULT.getValue(), SELECTED_ATTR);
-
-    context.updateItemCount(BiFields.OPTION.getValue(), attributesMapBi);
-  }
-
   @Override
   protected void buildAttribute(MessageMLParser parser,
       Node item) throws InvalidInputException {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
@@ -159,14 +159,22 @@ public class Select extends FormElement implements LabelableElement, Tooltipable
     this.putOneIfPresent(attributesMapBi, BiFields.REQUIRED.getValue(), REQUIRED_ATTR);
     this.putOneIfPresent(attributesMapBi, BiFields.MULTI_SELECT.getValue(), MULTIPLE_ATTR);
 
+    attributesMapBi.put(BiFields.OPTIONS_COUNT.getValue(), countChildrenOfType(Option.class));
+    attributesMapBi.put(BiFields.DEFAULT.getValue(), isAtLeastOneOptionSelected());
+
     context.addItem(new BiItem(BiFields.SELECT.getValue(), attributesMapBi));
+  }
+
+  private int isAtLeastOneOptionSelected() {
+    return getChildren().stream()
+            .anyMatch(child -> child.getAttribute(OPTION_SELECTED_ATTR) != null) ? 1 : 0;
   }
 
   private void assertOnlyOneOptionSelected() throws InvalidInputException {
     long numberOfSelectedOptions = getChildren().stream()
-        .map(child -> child.getAttribute(OPTION_SELECTED_ATTR))
-        .filter(selectedAttr -> selectedAttr != null && selectedAttr.equalsIgnoreCase(Boolean.TRUE.toString()))
-        .count();
+            .map(child -> child.getAttribute(OPTION_SELECTED_ATTR))
+            .filter(selectedAttr -> selectedAttr != null && selectedAttr.equalsIgnoreCase(Boolean.TRUE.toString()))
+            .count();
 
     if (numberOfSelectedOptions > 1) {
       throw new InvalidInputException("Element \"select\" can only have one selected \"option\"");

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/SelectOptionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/SelectOptionTest.java
@@ -711,11 +711,8 @@ public class SelectOptionTest extends ElementTest {
         {BiFields.LABEL.getValue(), 1},
         {BiFields.PLACEHOLDER.getValue(), 1},
         {BiFields.REQUIRED.getValue(), 1},
-    }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
-
-    Map<Object, Object> optionExpectedAttributes = Stream.of(new Object[][] {
-        {BiFields.DEFAULT.getValue(), 1},
         {BiFields.OPTIONS_COUNT.getValue(), 3},
+        {BiFields.DEFAULT.getValue(), 1}
     }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
 
     BiItem selectBiItemExpected = new BiItem(BiFields.SELECT.getValue(),
@@ -724,21 +721,13 @@ public class SelectOptionTest extends ElementTest {
             .collect(Collectors.toMap(e ->
                 String.valueOf(e.getKey()), Map.Entry::getValue)));
 
-    BiItem optionBiItemExpected = new BiItem(BiFields.OPTION.getValue(),
-        optionExpectedAttributes.entrySet()
-            .stream()
-            .collect(Collectors.toMap(e ->
-                String.valueOf(e.getKey()), Map.Entry::getValue)));
-
     BiItem formBiItemExpected = new BiItem(BiFields.FORM.getValue(), Collections.emptyMap());
 
-    assertEquals(5, items.size());
-    assertEquals(BiFields.OPTION.getValue(), items.get(0).getName());
-    assertEquals(BiFields.SELECT.getValue(), items.get(1).getName());
-    assertSameBiItem(optionBiItemExpected, items.get(0));
-    assertSameBiItem(selectBiItemExpected, items.get(1));
-    assertSameBiItem(formBiItemExpected, items.get(3));
-    assertMessageLengthBiItem(items.get(4), input.length());
+    assertEquals(4, items.size());
+    assertEquals(BiFields.SELECT.getValue(), items.get(0).getName());
+    assertSameBiItem(selectBiItemExpected, items.get(0));
+    assertSameBiItem(formBiItemExpected, items.get(2));
+    assertMessageLengthBiItem(items.get(3), input.length());
   }
 
   @Test
@@ -765,6 +754,8 @@ public class SelectOptionTest extends ElementTest {
         {BiFields.LABEL.getValue(), 1},
         {BiFields.PLACEHOLDER.getValue(), 1},
         {BiFields.REQUIRED.getValue(), 1},
+        {BiFields.OPTIONS_COUNT.getValue(), 3},
+        {BiFields.DEFAULT.getValue(), 1}
     }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
 
     BiItem selectBiItemExpected = new BiItem(BiFields.SELECT.getValue(),
@@ -773,11 +764,59 @@ public class SelectOptionTest extends ElementTest {
             .collect(Collectors.toMap(e ->
                 String.valueOf(e.getKey()), Map.Entry::getValue)));
 
-    assertEquals(5, items.size());
-    assertEquals(BiFields.SELECT.getValue(), items.get(1).getName());
-    assertSameBiItem(selectBiItemExpected, items.get(1));
+    assertEquals(4, items.size());
+    assertEquals(BiFields.SELECT.getValue(), items.get(0).getName());
+    assertSameBiItem(selectBiItemExpected, items.get(0));
   }
 
+
+  @Test
+  public void testBiContextMultipleSelect() throws InvalidInputException, IOException, ProcessingException {
+    MessageMLContext messageMLContext = new MessageMLContext(null);
+    String input = "<messageML>\n" +
+            "  <form id=\"form_id\">\n" +
+            "    <h2>dropdown menus</h2>\n" +
+            "      <select name=\"data-placeholder\" data-placeholder=\"Only data-placeholder\"><option value=\"opt1\">Unselected option 1</option><option value=\"opt2\">Unselected option 2</option><option value=\"opt3\">Unselected option 3</option></select>\n" +
+            "      <select name=\"multiple\" label=\"With multiple select options - between 3 and 5\" multiple=\"true\" min=\"3\" max=\"5\"><option value=\"opt1\" selected=\"true\">Preselected option 1</option><option value=\"opt2\" selected=\"true\">Preselected option 2</option><option value=\"opt3\" selected=\"true\">Preselected option 3</option><option value=\"opt4\">Unselected option 4</option><option value=\"opt5\">Unselected option 5</option><option value=\"opt6\">Unselected option 6</option></select>\n" +
+            "      <button name=\"dropdown\">Submit</button>\n" +
+            "  </form>\n" +
+            "</messageML>";
+
+    messageMLContext.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    List<BiItem> items = messageMLContext.getBiContext().getItems();
+
+    Map<Object, Object> selectExpectedAttributes = Stream.of(new Object[][] {
+            {BiFields.MULTI_SELECT.getValue(), 1},
+            {BiFields.LABEL.getValue(), 1},
+            {BiFields.OPTIONS_COUNT.getValue(), 6},
+            {BiFields.DEFAULT.getValue(), 1}
+    }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
+
+    BiItem selectBiItemExpected = new BiItem(BiFields.SELECT.getValue(),
+            selectExpectedAttributes.entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(e ->
+                            String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+    Map<Object, Object> selectExpectedAttributes1 = Stream.of(new Object[][] {
+            {BiFields.PLACEHOLDER.getValue(), 1},
+            {BiFields.OPTIONS_COUNT.getValue(), 3},
+            {BiFields.DEFAULT.getValue(), 0}
+    }).collect(Collectors.toMap(property -> property[0], property -> property[1]));
+
+    BiItem selectBiItemExpected1 = new BiItem(BiFields.SELECT.getValue(),
+            selectExpectedAttributes1.entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(e ->
+                            String.valueOf(e.getKey()), Map.Entry::getValue)));
+
+
+    assertEquals(6, items.size());
+    assertEquals(BiFields.SELECT.getValue(), items.get(1).getName());
+    assertSameBiItem(selectBiItemExpected1, items.get(1));
+    assertEquals(BiFields.SELECT.getValue(), items.get(2).getName());
+    assertSameBiItem(selectBiItemExpected, items.get(2));
+  }
   private String getRequiredPresentationML(String required) {
     if (required != null) {
       if (required.equals("true") || required.equals("false")) {


### PR DESCRIPTION
Option counts inside a dropdown menu should not generate a bi metric by its own. Goal of this PR is to include the options_count + the defauld field as part of the same Bi Item containing the dropdown menu.

### :white_check_mark: Checklist 
- [x] Unit tests and Javadoc
- [x] Generated PresentationML is valid
> :warning: For this point, please make sure that you have also added a complete example in the 
> `/examples` resources folder. This way the `Mml2Pml2Pml.java` test will ensure that the generated PresentationML is 
> an actual MessageML valid one. 
