### PR TITLE
Removing cashtag regex limitation

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/CashTag.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/CashTag.java
@@ -34,8 +34,6 @@ public class CashTag extends Keyword {
   public static final String MESSAGEML_TAG = "cash";
   public static final String PREFIX = "$";
   public static final String ENTITY_TYPE = "org.symphonyoss.fin.security";
-  public static final String CASHTAG_PATTERN =
-      "^(?!(?:[0-9,.]+$))(?!(?:[0-9,.]+(m|b|t|mm|bn|M|B|T|MM|BN|\\+|\\-|\\)|\\(|\\[|\\]|\\*|\\/)(\\s|$)))[^\\s\\$]*[^\\s!@#$%^&*()+=<>,.\\/?`~:;'\"\\\\|\\-]+[^\\s\\$]*$";
   private static final String ENTITY_SUBTYPE = "org.symphonyoss.fin.security.id.ticker";
   private static final String ENTITY_VERSION = "1.0";
 
@@ -68,11 +66,6 @@ public class CashTag extends Keyword {
   @Override
   public String toString() {
     return "CashTag(" + getTag() + ")";
-  }
-
-  @Override
-  public String getTagPattern() {
-    return CASHTAG_PATTERN;
   }
 
   @Override

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/HashTag.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/HashTag.java
@@ -20,6 +20,7 @@ import org.commonmark.node.Node;
 import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.bi.BiFields;
 import org.symphonyoss.symphony.messageml.bi.BiItem;
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
 import org.symphonyoss.symphony.messageml.markdown.nodes.KeywordNode;
 
 import java.util.Collections;
@@ -37,6 +38,7 @@ public class HashTag extends Keyword {
   public static final String HASHTAG_PATTERN = "[\\S]*[^\\s!@#$%^&*()+=<>,./?`~:;'\"\\\\|-]+[\\S]*$";
   private static final String ENTITY_SUBTYPE = "org.symphonyoss.taxonomy.hashtag";
   private static final String ENTITY_VERSION = "1.0";
+  private static final String MSG_INVALID_TAG_PATTERN = "Values of the attribute 'tag' for the element '%s' must match the pattern %s.";
 
   public HashTag(Element parent, int entityIndex) {
     super(parent, MESSAGEML_TAG, DEFAULT_PRESENTATIONML_TAG, FormatEnum.MESSAGEML);
@@ -55,6 +57,19 @@ public class HashTag extends Keyword {
   }
 
   @Override
+  public void validate() throws InvalidInputException {
+    String pattern = getTagPattern();
+    if (!this.tag.matches(pattern)) {
+      throw new InvalidInputException(String.format(MSG_INVALID_TAG_PATTERN, this.getMessageMLTag(), pattern));
+    }
+    super.validate();
+  }
+
+  public String getTagPattern() {
+    return HASHTAG_PATTERN;
+  }
+
+  @Override
   public String asText() {
     return "#" + getTag();
   }
@@ -67,11 +82,6 @@ public class HashTag extends Keyword {
   @Override
   public String toString() {
     return "HashTag(" + getTag() + ")";
-  }
-
-  @Override
-  public String getTagPattern() {
-    return HASHTAG_PATTERN;
   }
 
   @Override

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Keyword.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Keyword.java
@@ -32,7 +32,6 @@ abstract class Keyword extends Entity {
 
   private static final String ATTR_TAG = "tag";
   private static final String ENTITY_ID_PREFIX = "keyword";
-  private static final String MSG_INVALID_TAG_PATTERN = "Values of the attribute 'tag' for the element '%s' must match the pattern %s.";
 
   protected String tag;
 
@@ -43,12 +42,10 @@ abstract class Keyword extends Entity {
   @Override
   protected void buildAttribute(MessageMLParser parser,
       Node item) throws InvalidInputException {
-    switch (item.getNodeName()) {
-      case ATTR_TAG:
-        this.tag = item.getTextContent();
-        break;
-      default:
-          super.buildAttribute(parser, item);
+    if (ATTR_TAG.equals(item.getNodeName())) {
+      this.tag = item.getTextContent();
+    } else {
+      super.buildAttribute(parser, item);
     }
   }
 
@@ -57,11 +54,6 @@ abstract class Keyword extends Entity {
     if (this.tag == null) {
       throw new InvalidInputException("The attribute \"tag\" is required");
     }
-    String pattern = getTagPattern();
-    if (!this.tag.matches(pattern)) {
-      throw new InvalidInputException(String.format(MSG_INVALID_TAG_PATTERN, this.getMessageMLTag(), pattern));
-    }
-
     super.validate();
   }
 
@@ -90,9 +82,4 @@ abstract class Keyword extends Entity {
     return "Keyword(" + getTag() + ")";
   }
 
-  /**
-   * a Keyword must provide its validation pattern
-   * @return
-   */
-  public abstract String getTagPattern();
 }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/CashtagTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/CashtagTest.java
@@ -46,6 +46,30 @@ public class CashtagTest extends ElementTest {
   }
 
   @Test
+  public void testCashTagWithSpaceAndOnlyNumbers() throws Exception {
+    String input = "<messageML>Hello <cash tag=\"1234 789\"/>!</messageML>";
+
+    String expectedPresentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\">"
+            + "Hello <span class=\"entity\" data-entity-id=\"keyword1\">$1234 789</span>!"
+            + "</div>";
+    String expectedJson = "{\"keyword1\":{"
+            + "\"type\":\"org.symphonyoss.fin.security\","
+            + "\"version\":\"1.0\","
+            + "\"id\":[{"
+            + "\"type\":\"org.symphonyoss.fin.security.id.ticker\","
+            + "\"value\":\"1234 789\""
+            + "}]}}";
+    String expectedText = "1234 789";
+    String expectedMarkdown = "Hello $1234 789!";
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    assertEquals("Element attributes", Collections.emptyMap(), messageML.getChildren().get(1).getAttributes());
+    verifyCashTag(messageML, expectedPresentationML, expectedJson, expectedText, expectedMarkdown);
+  }
+
+  @Test
   public void testCashTagNonAlnum() throws Exception {
     String input = "<messageML>Hello <cash tag=\"_hello.w-o-r-l-d_\"/>!</messageML>";
 
@@ -166,38 +190,6 @@ public class CashtagTest extends ElementTest {
     expectedException.expect(InvalidInputException.class);
     expectedException.expectMessage("The attribute \"data-entity-id\" is required");
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
-  }
-
-  @Test
-  public void testCashTagInvalidCharacter() throws Exception {
-    String input = "<messageML>Hello <cash tag=\"invalid chars!\"/></messageML>";
-
-    expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage(
-        String.format("Values of the attribute 'tag' for the element 'cash' must match the pattern %s",
-            CashTag.CASHTAG_PATTERN));
-    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
-  }
-
-  @Test
-  public void testCashTagByPresentationMLInvalidCharacter() throws Exception {
-    String input = "<div data-format=\"PresentationML\" data-version=\"2.0\">"
-        + "Hello <div class=\"entity\" data-entity-id=\"cash123\">world</div>!"
-        + "</div>";
-
-    String entityJson = "{\"cash123\":{"
-        + "\"type\":\"org.symphonyoss.fin.security\","
-        + "\"version\":\"1.0\","
-        + "\"id\":[{"
-        + "\"type\":\"org.symphonyoss.fin.security.id.ticker\","
-        + "\"value\":\"invalid chars!\""
-        + "}]}}";
-
-    expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage(
-        String.format("Values of the attribute 'tag' for the element 'cash' must match the pattern %s",
-            CashTag.CASHTAG_PATTERN));
-    context.parseMessageML(input, entityJson, MessageML.MESSAGEML_VERSION);
   }
 
   @Test


### PR DESCRIPTION
 Removing the regex limitation we currently enforce on cashtags format, starting from now we'll start accepting cashtags containing whitespaces and numeric-only tags.