### PR TITLE
 #365 add support of sup and sub tags

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -62,6 +62,8 @@ import org.symphonyoss.symphony.messageml.elements.Radio;
 import org.symphonyoss.symphony.messageml.elements.Select;
 import org.symphonyoss.symphony.messageml.elements.Span;
 import org.symphonyoss.symphony.messageml.elements.SplittableElement;
+import org.symphonyoss.symphony.messageml.elements.Sub;
+import org.symphonyoss.symphony.messageml.elements.Sup;
 import org.symphonyoss.symphony.messageml.elements.Table;
 import org.symphonyoss.symphony.messageml.elements.TableBody;
 import org.symphonyoss.symphony.messageml.elements.TableCell;
@@ -609,6 +611,12 @@ public class MessageMLParser {
         String id = getAttribute(element, LabelableElement.LABEL_FOR);
         createSplittable(id, LabelableElement.class, Pair.of(LabelableElement.LABEL, element.getTextContent()));
         return null;
+
+      case Sub.MESSAGEML_TAG:
+        return new Sub(parent);
+
+      case Sup.MESSAGEML_TAG:
+        return new Sup(parent);
 
       default:
         throw new InvalidInputException("Invalid MessageML content at element \"" + tag + "\"");

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Sub.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Sub.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2017 MessageML - Symphony LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.symphonyoss.symphony.messageml.elements;
+
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+
+/**
+ * Class representing sub element.
+ *
+ * @author mohamed
+ * @since 6/06/23
+ */
+public class Sub extends Element {
+  public static final String MESSAGEML_TAG = "sub";
+
+  public Sub(Element parent) {
+    super(parent, MESSAGEML_TAG);
+  }
+
+  @Override
+  public void validate() throws InvalidInputException {
+    assertPhrasingContent();
+  }
+}

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Sup.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Sup.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-2017 MessageML - Symphony LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.symphonyoss.symphony.messageml.elements;
+
+import org.commonmark.node.Emphasis;
+import org.commonmark.node.Node;
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+
+/**
+ * Class representing sub element.
+ *
+ * @author mohamed
+ * @since 6/06/23
+ */
+public class Sup extends Element {
+  public static final String MESSAGEML_TAG = "sup";
+
+  public Sup(Element parent) {
+    super(parent, MESSAGEML_TAG);
+  }
+
+  @Override
+  public void validate() throws InvalidInputException {
+    assertPhrasingContent();
+  }
+
+}

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/SubTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/SubTest.java
@@ -1,0 +1,61 @@
+package org.symphonyoss.symphony.messageml.elements;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Test;
+import org.symphonyoss.symphony.messageml.bi.BiContext;
+import org.symphonyoss.symphony.messageml.bi.BiFields;
+import org.symphonyoss.symphony.messageml.bi.BiItem;
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+
+import java.util.Collections;
+
+public class SubTest extends ElementTest {
+
+  @Test
+  public void testSub() throws Exception {
+    String input = "<messageML><sub>Hello world!</sub></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    assertEquals("Element children", 1, messageML.getChildren().size());
+
+    Element sub = messageML.getChildren().get(0);
+
+    assertEquals("Element class", Sub.class, sub.getClass());
+    assertEquals("Element tag name", "sub", sub.getMessageMLTag());
+    assertEquals("Element attributes", Collections.emptyMap(), sub.getAttributes());
+    assertEquals("Element children", 1, sub.getChildren().size());
+    assertEquals("Child element", TextNode.class, sub.getChildren().get(0).getClass());
+    assertEquals("Child element text", "Hello world!", sub.getChildren().get(0).asText());
+    assertEquals("PresentationML", "<div data-format=\"PresentationML\" data-version=\"2.0\"><sub>Hello world!</sub></div>",
+        context.getPresentationML());
+    assertEquals("Markdown", "Hello world!", context.getMarkdown());
+    assertEquals("EntityJSON", new ObjectNode(JsonNodeFactory.instance), context.getEntityJson());
+    assertEquals("Legacy entities", new ObjectNode(JsonNodeFactory.instance), context.getEntities());
+
+    String withAttr = "<messageML><b class=\"label\">Hello world!</b></messageML>";
+    context.parseMessageML(withAttr, null, MessageML.MESSAGEML_VERSION);
+    sub = context.getMessageML().getChildren().get(0);
+    assertEquals("Attribute count", 1, sub.getAttributes().size());
+    assertEquals("Attribute", "label", sub.getAttribute("class"));
+
+    String styleAttr = "<messageML><b style=\"color:green\">Hello world!</b></messageML>";
+    context.parseMessageML(styleAttr, null, MessageML.MESSAGEML_VERSION);
+    sub = context.getMessageML().getChildren().get(0);
+    assertEquals("Attribute count", 1, sub.getAttributes().size());
+    assertEquals("Attribute", "color:green", sub.getAttribute("style"));
+  }
+
+
+  @Test
+  public void testSubInvalidAttr() throws Exception {
+    String invalidAttr = "<messageML>Hello <sub title=\"label\">world!</sub></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"title\" is not allowed in \"sub\"");
+    context.parseMessageML(invalidAttr, null, MessageML.MESSAGEML_VERSION);
+  }
+
+}

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/SupTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/SupTest.java
@@ -1,0 +1,58 @@
+package org.symphonyoss.symphony.messageml.elements;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Test;
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class SupTest extends ElementTest {
+
+  @Test
+  public void testSup() throws Exception {
+    String input = "<messageML>Hello <sup>world!</sup></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    assertEquals("Element children", 2, messageML.getChildren().size());
+
+    Element sup = messageML.getChildren().get(1);
+
+    assertEquals("Element class", Sup.class, sup.getClass());
+    assertEquals("Element tag name", "sup", sup.getMessageMLTag());
+    assertEquals("Element attributes", Collections.emptyMap(), sup.getAttributes());
+    assertEquals("Element children", 1, sup.getChildren().size());
+    assertEquals("Child element", TextNode.class, sup.getChildren().get(0).getClass());
+    assertEquals("Child element text", "world!", sup.getChildren().get(0).asText());
+    assertEquals("PresentationML", "<div data-format=\"PresentationML\" data-version=\"2.0\">Hello <sup>world!</sup></div>",
+        context.getPresentationML());
+    assertEquals("Markdown", "Hello world!", context.getMarkdown());
+    assertEquals("EntityJSON", new ObjectNode(JsonNodeFactory.instance), context.getEntityJson());
+    assertEquals("Legacy entities", new ObjectNode(JsonNodeFactory.instance), context.getEntities());
+
+    String withAttr = "<messageML><b class=\"label\">Hello world!</b></messageML>";
+    context.parseMessageML(withAttr, null, MessageML.MESSAGEML_VERSION);
+    sup = context.getMessageML().getChildren().get(0);
+    assertEquals("Attribute count", 1, sup.getAttributes().size());
+    assertEquals("Attribute", "label", sup.getAttribute("class"));
+
+    String styleAttr = "<messageML><b style=\"color:green\">Hello world!</b></messageML>";
+    context.parseMessageML(styleAttr, null, MessageML.MESSAGEML_VERSION);
+    sup = context.getMessageML().getChildren().get(0);
+    assertEquals("Attribute count", 1, sup.getAttributes().size());
+    assertEquals("Attribute", "color:green", sup.getAttribute("style"));
+  }
+
+
+  @Test
+  public void testSupInvalidAttr() throws Exception {
+    String invalidAttr = "<messageML>Hello <sup title=\"label\">world!</sup></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"title\" is not allowed in \"sup\"");
+    context.parseMessageML(invalidAttr, null, MessageML.MESSAGEML_VERSION);
+  }
+
+}


### PR DESCRIPTION
### :white_check_mark: Checklist 
- [ ] Unit tests and Javadoc
- [ ] Generated PresentationML is valid
> :warning: For this point, please make sure that you have also added a complete example in the 
> `/examples` resources folder. This way the `Mml2Pml2Pml.java` test will ensure that the generated PresentationML is 
> an actual MessageML valid one. 
