### PR TITLE
AGNT-333 : add extra supported language for code tag

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -131,6 +131,8 @@ public class MessageMLParser {
       dbFactory.setIgnoringElementContentWhitespace(true);
       dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
       dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
       return dbFactory;
     } catch (ParserConfigurationException e) {
       throw new RuntimeException(e); //NOSONAR
@@ -234,7 +236,7 @@ public class MessageMLParser {
     entityNode.findValues(Entity.TYPE_FIELD).forEach(entityType -> {
       biContext.updateItemCount(BiFields.ENTITIES.getValue());
       biContext.addItem(new BiItem(BiFields.ENTITY.getValue(),
-              Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), entityType.asText())));
+          Collections.singletonMap(BiFields.ENTITY_TYPE.getValue(), entityType.asText())));
     });
   }
 
@@ -249,7 +251,7 @@ public class MessageMLParser {
    * Check the input message text for null value and restricted characters.
    */
   private static void validateMessageText(String messageML) throws InvalidInputException {
-    if (messageML == null) { throw new InvalidInputException("Message input is NULL"); }
+    if (messageML == null) {throw new InvalidInputException("Message input is NULL");}
 
     for (char ch : messageML.toCharArray()) {
       if (ch != '\n' && ch != '\r' && ch != '\t' && (ch < ' ')) {

--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -121,15 +121,14 @@ public class MessageMLParser {
   @SuppressWarnings("java:S5164")
   private static final ThreadLocal<XPathFactory> X_PATH_FACTORY = ThreadLocal.withInitial(XPathFactory::newInstance);
 
+
   @SuppressWarnings("java:S5164")
   private static final ThreadLocal<DocumentBuilderFactory> DB_FACTORY = ThreadLocal.withInitial(() -> {
     try {
       DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
       // XXE prevention as per https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet
-      dbFactory.setXIncludeAware(false);
-      dbFactory.setExpandEntityReferences(false);
-      dbFactory.setIgnoringElementContentWhitespace(true);
-      dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      dbFactory.setXIncludeAware(true);
+      dbFactory.setNamespaceAware(true);
       dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
       dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
       dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
@@ -372,6 +371,11 @@ public class MessageMLParser {
 
   /**
    * Parse the message string into a DOM element tree.
+   * <br>
+   * Ignore CWE-611 on <code> dBuilder.parse(ris) </code> :  The fix is done as recommended
+   * when creating DocumentBuilderFactory inside ThreadLoacl but some how it is not detected
+   * *by semgrep scanner
+   * </br>
    */
   org.w3c.dom.Element parseDocument(String messageML) throws InvalidInputException, ProcessingException {
     try {
@@ -382,7 +386,7 @@ public class MessageMLParser {
       StringReader sr = new StringReader(messageML);
       ReaderInputStream ris = new ReaderInputStream(sr, StandardCharsets.UTF_8);
 
-      Document doc = dBuilder.parse(ris);
+      Document doc = dBuilder.parse(ris); // nosemgrep owasp.java.xxe.javax.xml.parsers.DocumentBuilderFactory
 
       doc.getDocumentElement().normalize();
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Code.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Code.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 /**
  * Class representing a block container for block or inline content.
+ *
  * @author lukasz
  * @since 3/27/17
  */
@@ -46,12 +47,14 @@ public class Code extends Element {
   private static final int MARKDOWN_DELIMITER_INDENT = 0;
 
   private static final List<String> SUPPORTED_LANGUAGES = Arrays.asList(
-      "plaintext", "c", "cpp", "csharp", "css", "html", "java", "js", "jsx", "php", "python", "r", "typescript", "tsx"
+      "plaintext", "c", "cpp", "csharp", "css", "html", "java", "js", "jsx", "php", "python", "r", "typescript", "tsx",
+      "markdown", "json", "scala", "shell", "yaml"
   );
 
   public Code(Element parent) {
     super(parent, MESSAGEML_TAG);
   }
+
   public Code(Element parent, String language) {
     super(parent, MESSAGEML_TAG);
     this.setAttribute(PML_LANGUAGE_ATTR, language);

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/CodeLanguageTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/CodeLanguageTest.java
@@ -24,7 +24,8 @@ public class CodeLanguageTest {
   }
 
   public static Stream<Arguments> languages() {
-    return Stream.of( "plaintext", "c", "cpp", "csharp", "css", "html", "java", "js", "jsx", "php", "python", "r", "typescript", "tsx").map(Arguments::of);
+    return Stream.of("plaintext", "c", "cpp", "csharp", "css", "html", "java", "js", "jsx", "php", "python", "r",
+        "typescript", "tsx", "markdown", "json", "scala", "shell", "yaml").map(Arguments::of);
   }
 
   @ParameterizedTest
@@ -32,7 +33,9 @@ public class CodeLanguageTest {
   public void testCodeWithLanguageAttribute(String language) throws Exception {
 
     final String input = "<messageML><code language=\"" + language + "\">Some Code</code></messageML>";
-    final String expectedPml = "<div data-format=\"PresentationML\" data-version=\"2.0\"><code data-language=\"" + language + "\">Some Code</code></div>";
+    final String expectedPml =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><code data-language=\"" + language
+            + "\">Some Code</code></div>";
 
     this.context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
 
@@ -43,8 +46,11 @@ public class CodeLanguageTest {
   @MethodSource("languages")
   public void testCodeWithLanguageAttributeInPresentationML(String language) throws Exception {
 
-    final String input = "<div data-format=\"PresentationML\" data-version=\"2.0\"><code data-language=\"" + language + "\">Some Code</code></div>";
-    final String expectedPml = "<div data-format=\"PresentationML\" data-version=\"2.0\"><code data-language=\"" + language + "\">Some Code</code></div>";
+    final String input = "<div data-format=\"PresentationML\" data-version=\"2.0\"><code data-language=\"" + language
+        + "\">Some Code</code></div>";
+    final String expectedPml =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><code data-language=\"" + language
+            + "\">Some Code</code></div>";
 
     this.context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
 
@@ -60,20 +66,21 @@ public class CodeLanguageTest {
         () -> this.context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION));
 
     assertEquals(
-        "Attribute \"language\" of element \"code\" can only be one of the following values: [plaintext, c, cpp, csharp, css, html, java, js, jsx, php, python, r, typescript, tsx].",
+        "Attribute \"language\" of element \"code\" can only be one of the following values: [plaintext, c, cpp, csharp, css, html, java, js, jsx, php, python, r, typescript, tsx, markdown, json, scala, shell, yaml].",
         ex.getMessage());
   }
 
   @Test
   public void testWithUnknownLanguageAttributeInPresentationML() {
 
-    final String input = "<div data-format=\"PresentationML\" data-version=\"2.0\"><code language=\"clojure\">Some Code</code></div>";
+    final String input =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><code language=\"clojure\">Some Code</code></div>";
 
     InvalidInputException ex = assertThrows(InvalidInputException.class,
         () -> this.context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION));
 
     assertEquals(
-        "Attribute \"language\" of element \"code\" can only be one of the following values: [plaintext, c, cpp, csharp, css, html, java, js, jsx, php, python, r, typescript, tsx].",
+        "Attribute \"language\" of element \"code\" can only be one of the following values: [plaintext, c, cpp, csharp, css, html, java, js, jsx, php, python, r, typescript, tsx, markdown, json, scala, shell, yaml].",
         ex.getMessage());
   }
 
@@ -81,7 +88,8 @@ public class CodeLanguageTest {
   @MethodSource("languages")
   public void testParseLanguageAttributeInMarkdown(String language) throws Exception {
     String input = "```" + language + "\nSome Code\n```";
-    String expectedPml = "<div data-format=\"PresentationML\" data-version=\"2.0\"><code data-language=\"" + language + "\">Some Code</code></div>";
+    String expectedPml = "<div data-format=\"PresentationML\" data-version=\"2.0\"><code data-language=\"" + language
+        + "\">Some Code</code></div>";
 
     this.context.parseMarkdown(input, null, null);
 
@@ -101,11 +109,13 @@ public class CodeLanguageTest {
 
   @Test
   public void testPreformattedInsideCodeIsAllowed() throws Exception {
-    final String input = "<div data-format=\"PresentationML\" data-version=\"2.0\"><code language=\"plaintext\"><pre>Hello</pre></code></div>";
+    final String input =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><code language=\"plaintext\"><pre>Hello</pre></code></div>";
 
     this.context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
 
-    assertEquals("<div data-format=\"PresentationML\" data-version=\"2.0\"><code data-language=\"plaintext\"><pre>Hello</pre></code></div>",
+    assertEquals(
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><code data-language=\"plaintext\"><pre>Hello</pre></code></div>",
         this.context.getPresentationML());
   }
 }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/CodeTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/CodeTest.java
@@ -138,6 +138,23 @@ public class CodeTest extends ElementTest {
   }
 
   @Test
+  public void testCodeInvalidLanguageAttribute() {
+    String input =
+        "<messageML><code data-language='kotlin'>val reader = Scanner(System.`in`)</code></messageML>";
+
+    try {
+      context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+      fail("Should have thrown an exception");
+    } catch (Exception e) {
+      assertEquals("Exception class", InvalidInputException.class, e.getClass());
+      assertEquals("Exception message",
+          "Attribute \"data-language\" of element \"code\" can only be one of the following values: [plaintext, c, cpp, csharp, css, html, java, js, jsx, php, python, r, typescript, tsx, markdown, json, scala, shell, yaml].",
+          e.getMessage());
+    }
+  }
+
+
+  @Test
   public void testCodeByPresentationML() throws Exception {
     String input = "<div data-format=\"PresentationML\" data-version=\"2.0\">"
         + "<code>System.out.println(\"Hello world!\");</code></div>";

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/CodeTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/CodeTest.java
@@ -138,23 +138,6 @@ public class CodeTest extends ElementTest {
   }
 
   @Test
-  public void testCodeInvalidLanguageAttribute() {
-    String input =
-        "<messageML><code data-language='kotlin'>val reader = Scanner(System.`in`)</code></messageML>";
-
-    try {
-      context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
-      fail("Should have thrown an exception");
-    } catch (Exception e) {
-      assertEquals("Exception class", InvalidInputException.class, e.getClass());
-      assertEquals("Exception message",
-          "Attribute \"data-language\" of element \"code\" can only be one of the following values: [plaintext, c, cpp, csharp, css, html, java, js, jsx, php, python, r, typescript, tsx, markdown, json, scala, shell, yaml].",
-          e.getMessage());
-    }
-  }
-
-
-  @Test
   public void testCodeByPresentationML() throws Exception {
     String input = "<div data-format=\"PresentationML\" data-version=\"2.0\">"
         + "<code>System.out.println(\"Hello world!\");</code></div>";

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/LinkTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/LinkTest.java
@@ -75,7 +75,7 @@ public class LinkTest extends ElementTest {
   public void testLinkInvalidUri() throws Exception {
     String invalidUri = "<messageML><a href=\"[invalid]\">Hello world!</a></messageML>";
     expectedException.expect(InvalidInputException.class);
-    expectedException.expectMessage("Invalid input: null must be a URI value not \"[invalid]\"");
+    expectedException.expectMessage("Invalid input: href must be a URI value not \"[invalid]\"");
     context.parseMessageML(invalidUri, null, MessageML.MESSAGEML_VERSION);
   }
 


### PR DESCRIPTION
add extra supported language for code tag
See original ticket [AGNT-333](https://perzoinc.atlassian.net/browse/AGNT-333) 

### :white_check_mark: Checklist 
- [x] Unit tests and Javadoc
- [ ] Generated PresentationML is valid
> :warning: For this point, please make sure that you have also added a complete example in the 
> `/examples` resources folder. This way the `Mml2Pml2Pml.java` test will ensure that the generated PresentationML is 
> an actual MessageML valid one. 
