### PR TITLE
[AGNT-333] add extra supported language to <code> tag

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Code.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Code.java
@@ -46,7 +46,8 @@ public class Code extends Element {
   private static final int MARKDOWN_DELIMITER_INDENT = 0;
 
   private static final List<String> SUPPORTED_LANGUAGES = Arrays.asList(
-      "plaintext", "c", "cpp", "csharp", "css", "html", "java", "js", "jsx", "php", "python", "r", "typescript", "tsx"
+      "plaintext", "c", "cpp", "csharp", "css", "html", "java", "js", "jsx", "php", "python", "r",
+      "typescript", "tsx", "markdown", "json", "scala", "shell", "yaml"
   );
 
   public Code(Element parent) {

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/CodeLanguageTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/CodeLanguageTest.java
@@ -24,7 +24,9 @@ public class CodeLanguageTest {
   }
 
   public static Stream<Arguments> languages() {
-    return Stream.of( "plaintext", "c", "cpp", "csharp", "css", "html", "java", "js", "jsx", "php", "python", "r", "typescript", "tsx").map(Arguments::of);
+    return Stream.of("plaintext", "c", "cpp", "csharp", "css", "html", "java", "js", "jsx", "php",
+            "python", "r", "typescript", "tsx", "markdown", "json", "scala", "shell", "yaml")
+        .map(Arguments::of);
   }
 
   @ParameterizedTest
@@ -60,7 +62,9 @@ public class CodeLanguageTest {
         () -> this.context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION));
 
     assertEquals(
-        "Attribute \"language\" of element \"code\" can only be one of the following values: [plaintext, c, cpp, csharp, css, html, java, js, jsx, php, python, r, typescript, tsx].",
+        "Attribute \"language\" of element \"code\" can only be one of the following values: "
+            + "[plaintext, c, cpp, csharp, css, html, java, js, jsx, php, python, r, typescript, "
+            + "tsx, markdown, json, scala, shell, yaml].",
         ex.getMessage());
   }
 
@@ -73,7 +77,9 @@ public class CodeLanguageTest {
         () -> this.context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION));
 
     assertEquals(
-        "Attribute \"language\" of element \"code\" can only be one of the following values: [plaintext, c, cpp, csharp, css, html, java, js, jsx, php, python, r, typescript, tsx].",
+        "Attribute \"language\" of element \"code\" can only be one of the following values: "
+            + "[plaintext, c, cpp, csharp, css, html, java, js, jsx, php, python, r, typescript, "
+            + "tsx, markdown, json, scala, shell, yaml].",
         ex.getMessage());
   }
 


### PR DESCRIPTION
add extra supported language (markdown, json, scala, shell, yaml) to <code> tag 
Jira Ticket https://perzoinc.atlassian.net/browse/AGNT-333
### :white_check_mark: Checklist 
- [ ] Unit tests and Javadoc
- [ ] Generated PresentationML is valid
> :warning: For this point, please make sure that you have also added a complete example in the 
> `/examples` resources folder. This way the `Mml2Pml2Pml.java` test will ensure that the generated PresentationML is 
> an actual MessageML valid one. 
