### PR TITLE
[AGNT-319] support <sup> and <sub> tags

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/MessageMLParser.java
@@ -62,6 +62,8 @@ import org.symphonyoss.symphony.messageml.elements.Radio;
 import org.symphonyoss.symphony.messageml.elements.Select;
 import org.symphonyoss.symphony.messageml.elements.Span;
 import org.symphonyoss.symphony.messageml.elements.SplittableElement;
+import org.symphonyoss.symphony.messageml.elements.Subscript;
+import org.symphonyoss.symphony.messageml.elements.Superscript;
 import org.symphonyoss.symphony.messageml.elements.Table;
 import org.symphonyoss.symphony.messageml.elements.TableBody;
 import org.symphonyoss.symphony.messageml.elements.TableCell;
@@ -615,6 +617,12 @@ public class MessageMLParser {
         String id = getAttribute(element, LabelableElement.LABEL_FOR);
         createSplittable(id, LabelableElement.class, Pair.of(LabelableElement.LABEL, element.getTextContent()));
         return null;
+
+      case Subscript.MESSAGEML_TAG:
+        return new Subscript(parent);
+
+      case Superscript.MESSAGEML_TAG:
+        return new Superscript(parent);
 
       default:
         throw new InvalidInputException("Invalid MessageML content at element \"" + tag + "\"");

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Element.java
@@ -81,7 +81,8 @@ public abstract class Element {
 
   private static final List<Class<? extends Element>> PHRASING_TYPES =
       Arrays.asList(TextNode.class, Link.class, Chime.class, Bold.class, Italic.class, Image.class,
-          LineBreak.class, Span.class, Emoji.class, HashTag.class, CashTag.class, Mention.class);
+          LineBreak.class, Span.class, Emoji.class, HashTag.class, CashTag.class, Mention.class,
+          Subscript.class, Superscript.class);
 
   private static final List<Class<? extends Element>> PHRASING_OR_PREFORMATTED_TYPES = new ArrayList<Class<? extends Element>>() {{
     addAll(PHRASING_TYPES);

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Subscript.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Subscript.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-2017 MessageML - Symphony LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.symphonyoss.symphony.messageml.elements;
+
+import org.commonmark.node.Emphasis;
+import org.commonmark.node.Node;
+
+/**
+ * Class representing Subscript text.
+ *
+ * @author Mohamed Rojbeni
+ * @since 09/12/23
+ */
+public class Subscript extends Element {
+  public static final String MESSAGEML_TAG = "sub";
+  private static final String MARKDOWN = "~";
+
+  public Subscript(Element parent) {
+    super(parent, MESSAGEML_TAG);
+  }
+
+  @Override
+  public Node asMarkdown() {
+    return new Emphasis(MARKDOWN);
+  }
+
+}

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Superscript.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Superscript.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-2017 MessageML - Symphony LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.symphonyoss.symphony.messageml.elements;
+
+import org.commonmark.node.Emphasis;
+import org.commonmark.node.Node;
+
+/**
+ * Class representing Superscript text.
+ *
+ * @author Mohamed Rojbeni
+ * @since 09/12/23
+ */
+public class Superscript extends Element {
+  public static final String MESSAGEML_TAG = "sup";
+  private static final String MARKDOWN = "^";
+
+  public Superscript(Element parent) {
+    super(parent, MESSAGEML_TAG);
+  }
+
+  @Override
+  public Node asMarkdown() {
+    return new Emphasis(MARKDOWN);
+  }
+
+}

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/SubscriptTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/SubscriptTest.java
@@ -1,0 +1,84 @@
+package org.symphonyoss.symphony.messageml.elements;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Test;
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+
+import java.util.Collections;
+
+public class SubscriptTest extends ElementTest {
+
+  @Test
+  public void testSubscript() throws Exception {
+    String input = "<messageML><sub>Hello world!</sub></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    assertEquals("Element children", 1, messageML.getChildren().size());
+
+    Element subscript = messageML.getChildren().get(0);
+
+    assertEquals("Element class", Subscript.class, subscript.getClass());
+    assertEquals("Element tag name", "sub", subscript.getMessageMLTag());
+    assertEquals("Element attributes", Collections.emptyMap(), subscript.getAttributes());
+    assertEquals("Element children", 1, subscript.getChildren().size());
+    assertEquals("Child element", TextNode.class, subscript.getChildren().get(0).getClass());
+    assertEquals("Child element text", "Hello world!", subscript.getChildren().get(0).asText());
+    assertEquals("PresentationML",
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><sub>Hello world!</sub></div>",
+        context.getPresentationML());
+    assertEquals("Markdown", "~Hello world!~", context.getMarkdown());
+    assertEquals("EntityJSON", new ObjectNode(JsonNodeFactory.instance), context.getEntityJson());
+    assertEquals("Legacy entities", new ObjectNode(JsonNodeFactory.instance),
+        context.getEntities());
+
+    String withAttr = "<messageML><sub class=\"label\">Hello world!</sub></messageML>";
+    context.parseMessageML(withAttr, null, MessageML.MESSAGEML_VERSION);
+    subscript = context.getMessageML().getChildren().get(0);
+    assertEquals("Attribute count", 1, subscript.getAttributes().size());
+    assertEquals("Attribute", "label", subscript.getAttribute("class"));
+
+    String styleAttr = "<messageML><sub style=\"background:red\">Hello world!</sub></messageML>";
+    context.parseMessageML(styleAttr, null, MessageML.MESSAGEML_VERSION);
+    subscript = context.getMessageML().getChildren().get(0);
+    assertEquals("Attribute count", 1, subscript.getAttributes().size());
+    assertEquals("Attribute", "background:red", subscript.getAttribute("style"));
+  }
+
+  @Test
+  public void testSubscriptInvalidAttr() throws Exception {
+    String invalidAttr = "<messageML><sub title=\"label\">Hello world!</sub></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"title\" is not allowed in \"sub\"");
+    context.parseMessageML(invalidAttr, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testSubscriptWithinParagraph() throws Exception {
+    String input = "<messageML><p>Hello <sub>World</sub>!</p></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    assertEquals("PresentationML",
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><p>Hello "
+            + "<sub>World</sub>!</p></div>",
+        context.getPresentationML());
+    assertEquals("Markdown", "Hello ~World~!\n\n", context.getMarkdown());
+    assertEquals("Plaintext", "Hello World!", context.getText());
+  }
+
+  @Test
+  public void testSubscriptWithinBold() throws Exception {
+    String input = "<messageML><b>Hello <sub>World</sub></b></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    assertEquals("PresentationML",
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><b>Hello "
+            + "<sub>World</sub></b></div>",
+        context.getPresentationML());
+    assertEquals("Markdown", "**Hello ~World~**", context.getMarkdown());
+    assertEquals("Plaintext", "Hello World", context.getText());
+  }
+}

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/SuperscriptTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/SuperscriptTest.java
@@ -1,0 +1,84 @@
+package org.symphonyoss.symphony.messageml.elements;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Test;
+import org.symphonyoss.symphony.messageml.exceptions.InvalidInputException;
+
+import java.util.Collections;
+
+public class SuperscriptTest extends ElementTest {
+
+  @Test
+  public void testSuperscript() throws Exception {
+    String input = "<messageML><sup>Hello world!</sup></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    Element messageML = context.getMessageML();
+    assertEquals("Element children", 1, messageML.getChildren().size());
+
+    Element superscript = messageML.getChildren().get(0);
+
+    assertEquals("Element class", Superscript.class, superscript.getClass());
+    assertEquals("Element tag name", "sup", superscript.getMessageMLTag());
+    assertEquals("Element attributes", Collections.emptyMap(), superscript.getAttributes());
+    assertEquals("Element children", 1, superscript.getChildren().size());
+    assertEquals("Child element", TextNode.class, superscript.getChildren().get(0).getClass());
+    assertEquals("Child element text", "Hello world!", superscript.getChildren().get(0).asText());
+    assertEquals("PresentationML",
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><sup>Hello world!</sup></div>",
+        context.getPresentationML());
+    assertEquals("Markdown", "^Hello world!^", context.getMarkdown());
+    assertEquals("EntityJSON", new ObjectNode(JsonNodeFactory.instance), context.getEntityJson());
+    assertEquals("Legacy entities", new ObjectNode(JsonNodeFactory.instance),
+        context.getEntities());
+
+    String withAttr = "<messageML><sup class=\"label\">Hello world!</sup></messageML>";
+    context.parseMessageML(withAttr, null, MessageML.MESSAGEML_VERSION);
+    superscript = context.getMessageML().getChildren().get(0);
+    assertEquals("Attribute count", 1, superscript.getAttributes().size());
+    assertEquals("Attribute", "label", superscript.getAttribute("class"));
+
+    String styleAttr = "<messageML><sup style=\"background:red\">Hello world!</sup></messageML>";
+    context.parseMessageML(styleAttr, null, MessageML.MESSAGEML_VERSION);
+    superscript = context.getMessageML().getChildren().get(0);
+    assertEquals("Attribute count", 1, superscript.getAttributes().size());
+    assertEquals("Attribute", "background:red", superscript.getAttribute("style"));
+  }
+
+  @Test
+  public void testSuperscriptInvalidAttr() throws Exception {
+    String invalidAttr = "<messageML><sup title=\"label\">Hello world!</sup></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"title\" is not allowed in \"sup\"");
+    context.parseMessageML(invalidAttr, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testSuperscriptWithinParagraph() throws Exception {
+    String input = "<messageML><p>Hello <sup>World</sup>!</p></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    assertEquals("PresentationML",
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><p>Hello "
+            + "<sup>World</sup>!</p></div>",
+        context.getPresentationML());
+    assertEquals("Markdown", "Hello ^World^!\n\n", context.getMarkdown());
+    assertEquals("Plaintext", "Hello World!", context.getText());
+  }
+
+  @Test
+  public void testSuperscriptWithinBold() throws Exception {
+    String input = "<messageML><b>Hello <sup>World</sup></b></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    assertEquals("PresentationML",
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><b>Hello "
+            + "<sup>World</sup></b></div>",
+        context.getPresentationML());
+    assertEquals("Markdown", "**Hello ^World^**", context.getMarkdown());
+    assertEquals("Plaintext", "Hello World", context.getText());
+  }
+}


### PR DESCRIPTION
### :white_check_mark: Checklist 
- [ ] Unit tests and Javadoc
- [ ] Generated PresentationML is valid
> :warning: For this point, please make sure that you have also added a complete example in the 
> `/examples` resources folder. This way the `Mml2Pml2Pml.java` test will ensure that the generated PresentationML is 
> an actual MessageML valid one. 
