### PR TITLE
[AGNT-366][C2-20892] support auto-submit attribute

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
@@ -16,6 +16,8 @@
 
 package org.symphonyoss.symphony.messageml.elements;
 
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.symphonyoss.symphony.messageml.MessageMLParser;
 import org.symphonyoss.symphony.messageml.bi.BiContext;
 import org.symphonyoss.symphony.messageml.bi.BiFields;
@@ -60,6 +62,9 @@ public class Select extends FormElement implements LabelableElement, Tooltipable
   private static final String MIN_ATTR = "data-min";
   private static final String MML_MAX_ATTR = "max";
   private static final String MAX_ATTR = "data-max";
+  private static final String MML_AUTO_SUBMIT_ATTR = "auto-submit";
+  private static final String AUTO_SUBMIT_ATTR = "data-auto-submit";
+
 
   public Select(Element parent) {
     super(parent, MESSAGEML_TAG);
@@ -88,6 +93,11 @@ public class Select extends FormElement implements LabelableElement, Tooltipable
 
     if (getAttribute(MULTIPLE_ATTR) != null) {
       assertAttributeValue(MULTIPLE_ATTR, Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString()));
+    }
+
+    if (getAttribute(AUTO_SUBMIT_ATTR) != null) {
+      assertAttributeValue(AUTO_SUBMIT_ATTR,
+          Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString()));
     }
 
     boolean multipleAttributeValue = Boolean.parseBoolean(getAttribute(MULTIPLE_ATTR));
@@ -132,6 +142,9 @@ public class Select extends FormElement implements LabelableElement, Tooltipable
         break;
       case MML_MAX_ATTR:
         setAttribute(MAX_ATTR, getStringAttribute(item));
+        break;
+      case MML_AUTO_SUBMIT_ATTR:
+        setAttribute(AUTO_SUBMIT_ATTR, getStringAttribute(item));
         break;
       case ID_ATTR:
         if (format != FormatEnum.PRESENTATIONML) {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TextField.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TextField.java
@@ -38,6 +38,9 @@ public class TextField extends FormElement implements RegexElement, LabelableEle
 
   private static final String PRESENTATIONML_MASKED_ATTR = "data-masked";
 
+  private static final String MML_AUTO_SUBMIT_ATTR = "auto-submit";
+  private static final String AUTO_SUBMIT_ATTR = "data-auto-submit";
+
   private static final Set<String> VALID_BOOLEAN_VALUES = new HashSet<>(Arrays.asList("true", "false"));
   private static final Integer MIN_ALLOWED_LENGTH = 1;
   private static final Integer MAX_ALLOWED_LENGTH = 128;
@@ -62,6 +65,10 @@ public class TextField extends FormElement implements RegexElement, LabelableEle
 
     if (getAttribute(MASKED_ATTR) != null) {
       assertAttributeValue(MASKED_ATTR, VALID_BOOLEAN_VALUES);
+    }
+
+    if (getAttribute(AUTO_SUBMIT_ATTR) != null) {
+      assertAttributeValue(AUTO_SUBMIT_ATTR, VALID_BOOLEAN_VALUES);
     }
 
     assertAttributeNotBlank(NAME_ATTR);
@@ -109,6 +116,9 @@ public class TextField extends FormElement implements RegexElement, LabelableEle
           throwInvalidInputException(item);
         }
         fillAttributes(parser, item);
+        break;
+      case MML_AUTO_SUBMIT_ATTR:
+        setAttribute(AUTO_SUBMIT_ATTR, getStringAttribute(item));
         break;
       default:
         throwInvalidInputException(item);
@@ -182,6 +192,10 @@ public class TextField extends FormElement implements RegexElement, LabelableEle
 
     if (getAttribute(MAXLENGTH_ATTR) != null) {
       presentationAttrs.put(MAXLENGTH_ATTR, getAttribute(MAXLENGTH_ATTR));
+    }
+
+    if (getAttribute(AUTO_SUBMIT_ATTR) != null) {
+      presentationAttrs.put(AUTO_SUBMIT_ATTR, getAttribute(AUTO_SUBMIT_ATTR));
     }
 
     if (getChildren() != null && getChildren().size() == 1) {

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/SelectOptionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/SelectOptionTest.java
@@ -688,6 +688,42 @@ public class SelectOptionTest extends ElementTest {
   }
 
   @Test
+  public void testAutoSubmitSelect() throws Exception {
+    //language=XML
+    String input =
+        "<messageML><form id=\"form_id\"><select name=\"auto-submit\" "
+            + "auto-submit=\"true\"><option value=\"opt1\">option 1</option><option "
+            + "value=\"opt2\">option 2</option><option value=\"opt3\">option "
+            + "3</option></select><button name=\"dropdown\">Submit</button></form></messageML>";
+
+    context.parseMessageML(trimXml(input), null, MessageML.MESSAGEML_VERSION);
+    //language=HTML
+    String expectedPresentationML =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"form_id\"><select "
+            + "data-auto-submit=\"true\" name=\"auto-submit\"><option value=\"opt1\">option "
+            + "1</option><option value=\"opt2\">option 2</option><option value=\"opt3\">option "
+            + "3</option></select><button type=\"action\" "
+            + "name=\"dropdown\">Submit</button></form></div>";
+    assertEquals(trimXml(expectedPresentationML), context.getPresentationML());
+  }
+
+  @Test
+  public void testAutoSubmitSelectInvalidAttribute() throws Exception {
+    //language=XML
+    String input =
+        "<messageML><form id=\"form_id\"><select name=\"auto-submit\" "
+            + "auto-submit=\"invalid\"><option value=\"opt1\">option 1</option><option "
+            + "value=\"opt2\">option 2</option><option value=\"opt3\">option "
+            + "3</option></select><button name=\"dropdown\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"data-auto-submit\" of element \"select\" can only be one of the following "
+            + "values: "
+            + "[true, false]");
+    context.parseMessageML(trimXml(input), null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testBiContextSelect()
       throws InvalidInputException, IOException, ProcessingException {
     MessageMLContext messageMLContext = new MessageMLContext(null);

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
@@ -709,6 +709,36 @@ public class TextFieldTest extends ElementTest {
     context.parseMessageML(messageMLInput, null, MessageML.MESSAGEML_VERSION);
   }
 
+  @Test
+  public void testAutoSubmitTextField() throws Exception {
+
+    String messageMLInput =
+        "<messageML><form id=\"form_id\"><text-field name=\"init\" auto-submit=\"true\">With "
+            + "initial value</text-field><button type=\"action\" "
+            + "name=\"text-field\">Submit</button></form></messageML>";
+    String expectedPresentationML =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"form_id\"><input "
+            + "type=\"text\" name=\"init\" data-auto-submit=\"true\" value=\"With initial "
+            + "value\"/><button type=\"action\" name=\"text-field\">Submit</button></form></div>";
+    context.parseMessageML(messageMLInput, null, MessageML.MESSAGEML_VERSION);
+    assertEquals("The parsed content should be equivalent to the expected presentation ML",
+        expectedPresentationML, context.getPresentationML());
+  }
+
+  @Test
+  public void testAutoSubmitTextFieldInvalid() throws Exception {
+
+    String messageMLInput =
+        "<messageML><form id=\"form_id\"><text-field name=\"init\" auto-submit=\"invalid\">With "
+            + "initial value</text-field><button type=\"action\" "
+            + "name=\"text-field\">Submit</button></form></messageML>";
+    exceptionRule.expect(InvalidInputException.class);
+    exceptionRule.expectMessage(
+        "Attribute \"data-auto-submit\" of element \"text-field\" can only be one of the "
+            + "following values: [true, false].");
+    context.parseMessageML(messageMLInput, null, MessageML.MESSAGEML_VERSION);
+  }
+
   private static Stream<Arguments> messageMlStream() {
     return Stream.of(
         Arguments.of(


### PR DESCRIPTION
[AGNT-366][C2-20892] add auto-submit attribute to select and text-field component

### :white_check_mark: Checklist 
- [ ] Unit tests and Javadoc
- [ ] Generated PresentationML is valid
> :warning: For this point, please make sure that you have also added a complete example in the 
> `/examples` resources folder. This way the `Mml2Pml2Pml.java` test will ensure that the generated PresentationML is 
> an actual MessageML valid one. 
