### PR TITLE
[AGNT-366][C2-20897] support disabled or readonly attributes

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Checkbox.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Checkbox.java
@@ -39,6 +39,16 @@ public class Checkbox extends GroupedElement implements LabelableElement {
       assertAttributeValue(CHECKED_ATTR, Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString()));
     }
 
+    if (getAttribute(DISABLED_ATTR) != null) {
+      assertAttributeValue(DISABLED_ATTR,
+          Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString()));
+    }
+
+    if (getAttribute(READONLY_ATTR) != null) {
+      assertAttributeValue(READONLY_ATTR,
+          Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString()));
+    }
+
     if (!getChildren().isEmpty()) {
       assertContentModel(Arrays.asList(TextNode.class, Bold.class, Italic.class));
     }
@@ -54,6 +64,8 @@ public class Checkbox extends GroupedElement implements LabelableElement {
       case VALUE_ATTR:
       case CHECKED_ATTR:
       case LABEL:
+      case DISABLED_ATTR:
+      case READONLY_ATTR:
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       case ID_ATTR:

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/DatePicker.java
@@ -45,6 +45,8 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
   private static final String PRESENTATIONML_DISABLED_DATE_ATTR = "data-disabled-date";
   private static final String PRESENTATIONML_HIGHLIGHTED_DATE_ATTR = "data-highlighted-date";
   private static final String PRESENTATIONML_FORMAT_ATTR = "data-format";
+  protected static final String DISABLED_ATTR = "disabled";
+  protected static final String READONLY_ATTR = "readonly";
 
   private static final String DATE_FORMAT_ALLOWED = "^[0-9Mdy\\/. -:]+$";
 
@@ -63,6 +65,8 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
       case MAX_ATTR:
       case LABEL:
       case TITLE:
+      case DISABLED_ATTR:
+      case READONLY_ATTR:
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       case DISABLED_DATE_ATTR:
@@ -107,6 +111,12 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
     }
     if (getAttribute(MAX_ATTR) != null) {
       assertDateFormat(MAX_ATTR, DateTimeFormatter.ISO_DATE);
+    }
+    if (getAttribute(DISABLED_ATTR) != null) {
+      assertAttributeValue(DISABLED_ATTR, Arrays.asList("true", "false"));
+    }
+    if (getAttribute(READONLY_ATTR) != null) {
+      assertAttributeValue(READONLY_ATTR, Arrays.asList("true", "false"));
     }
     assertJsonDatesRange(DISABLED_DATE_ATTR);
     assertJsonDatesRange(HIGHLIGHTED_DATE_ATTR);
@@ -177,6 +187,12 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
     if (getAttribute(FORMAT_ATTR) != null) {
       presentationAttrs.put(PRESENTATIONML_FORMAT_ATTR, getAttribute(FORMAT_ATTR));
     }
+    if (getAttribute(DISABLED_ATTR) != null) {
+      presentationAttrs.put(DISABLED_ATTR, getAttribute(DISABLED_ATTR));
+    }
+    if (getAttribute(READONLY_ATTR) != null) {
+      presentationAttrs.put(READONLY_ATTR, getAttribute(READONLY_ATTR));
+    }
     // PresentationML compatibility
     if (getAttribute(PRESENTATIONML_DISABLED_DATE_ATTR) != null) {
       presentationAttrs.put(PRESENTATIONML_DISABLED_DATE_ATTR, getAttribute(PRESENTATIONML_DISABLED_DATE_ATTR));
@@ -187,7 +203,6 @@ public class DatePicker extends FormElement implements LabelableElement, Tooltip
     if (getAttribute(PRESENTATIONML_FORMAT_ATTR) != null) {
       presentationAttrs.put(PRESENTATIONML_FORMAT_ATTR, getAttribute(PRESENTATIONML_FORMAT_ATTR));
     }
-
     return presentationAttrs;
   }
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/GroupedElement.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/GroupedElement.java
@@ -29,6 +29,9 @@ public abstract class GroupedElement extends FormElement {
   protected static final String VALUE_ATTR = "value";
   protected static final String CHECKED_ATTR = "checked";
   protected static final String FOR_ATTR = "for";
+  protected static final String DISABLED_ATTR = "disabled";
+  protected static final String READONLY_ATTR = "readonly";
+
 
   public GroupedElement(Element parent, String messageMLTag,
       FormatEnum format) {
@@ -188,6 +191,15 @@ public abstract class GroupedElement extends FormElement {
     } else {
       presentationAttrs.put(VALUE_ATTR, PRESENTATIONML_DEFAULT_VALUE);
     }
+
+    if (getAttribute(DISABLED_ATTR) != null) {
+      presentationAttrs.put(DISABLED_ATTR, getAttribute(DISABLED_ATTR));
+    }
+
+    if (getAttribute(READONLY_ATTR) != null) {
+      presentationAttrs.put(READONLY_ATTR, getAttribute(READONLY_ATTR));
+    }
+
     return presentationAttrs;
   }
 

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Radio.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Radio.java
@@ -67,6 +67,16 @@ public class Radio extends GroupedElement implements LabelableElement{
       assertAttributeValue(CHECKED_ATTR, Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString()));
     }
 
+    if (getAttribute(DISABLED_ATTR) != null) {
+      assertAttributeValue(DISABLED_ATTR,
+          Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString()));
+    }
+
+    if (getAttribute(READONLY_ATTR) != null) {
+      assertAttributeValue(READONLY_ATTR,
+          Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString()));
+    }
+
     if (!getChildren().isEmpty()) {
       assertContentModel(Arrays.asList(TextNode.class, Bold.class, Italic.class));
     }
@@ -80,6 +90,8 @@ public class Radio extends GroupedElement implements LabelableElement{
       case NAME_ATTR:
       case VALUE_ATTR:
       case LABEL:
+      case DISABLED_ATTR:
+      case READONLY_ATTR:
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       case ID_ATTR:

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Select.java
@@ -60,6 +60,8 @@ public class Select extends FormElement implements LabelableElement, Tooltipable
   private static final String MIN_ATTR = "data-min";
   private static final String MML_MAX_ATTR = "max";
   private static final String MAX_ATTR = "data-max";
+  protected static final String DISABLED_ATTR = "disabled";
+  protected static final String READONLY_ATTR = "readonly";
 
   public Select(Element parent) {
     super(parent, MESSAGEML_TAG);
@@ -88,6 +90,16 @@ public class Select extends FormElement implements LabelableElement, Tooltipable
 
     if (getAttribute(MULTIPLE_ATTR) != null) {
       assertAttributeValue(MULTIPLE_ATTR, Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString()));
+    }
+
+    if (getAttribute(DISABLED_ATTR) != null) {
+      assertAttributeValue(DISABLED_ATTR,
+          Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString()));
+    }
+
+    if (getAttribute(READONLY_ATTR) != null) {
+      assertAttributeValue(READONLY_ATTR,
+          Arrays.asList(Boolean.TRUE.toString(), Boolean.FALSE.toString()));
     }
 
     boolean multipleAttributeValue = Boolean.parseBoolean(getAttribute(MULTIPLE_ATTR));
@@ -125,6 +137,8 @@ public class Select extends FormElement implements LabelableElement, Tooltipable
       case LABEL:
       case TITLE:
       case MULTIPLE_ATTR:
+      case DISABLED_ATTR:
+      case READONLY_ATTR:
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       case MML_MIN_ATTR:

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TextArea.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TextArea.java
@@ -28,6 +28,8 @@ public class TextArea extends FormElement implements RegexElement, LabelableElem
 
   private static final String PLACEHOLDER_ATTR = "placeholder";
   private static final String REQUIRED_ATTR = "required";
+  private static final String DISABLED_ATTR = "disabled";
+  private static final String READONLY_ATTR = "readonly";
   private static final List<String> VALID_VALUES_FOR_REQUIRED_ATTR = Arrays.asList("true", "false");
 
   public TextArea(Element parent, FormatEnum format) {
@@ -44,6 +46,14 @@ public class TextArea extends FormElement implements RegexElement, LabelableElem
 
     if (getAttribute(REQUIRED_ATTR) != null) {
       assertAttributeValue(REQUIRED_ATTR, VALID_VALUES_FOR_REQUIRED_ATTR);
+    }
+
+    if (getAttribute(DISABLED_ATTR) != null) {
+      assertAttributeValue(DISABLED_ATTR, VALID_VALUES_FOR_REQUIRED_ATTR);
+    }
+
+    if (getAttribute(READONLY_ATTR) != null) {
+      assertAttributeValue(READONLY_ATTR, VALID_VALUES_FOR_REQUIRED_ATTR);
     }
 
     assertAttributeNotBlank(NAME_ATTR);
@@ -64,6 +74,8 @@ public class TextArea extends FormElement implements RegexElement, LabelableElem
       case PATTERN_ATTR:
       case LABEL:
       case TITLE:
+      case DISABLED_ATTR:
+      case READONLY_ATTR:
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       case PATTERN_ERROR_MESSAGE_ATTR:

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TextField.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TextField.java
@@ -35,7 +35,8 @@ public class TextField extends FormElement implements RegexElement, LabelableEle
   private static final String MASKED_ATTR = "masked";
   private static final String PLACEHOLDER_ATTR = "placeholder";
   private static final String VALUE_ATTR = "value";
-
+  private static final String DISABLED_ATTR = "disabled";
+  private static final String READONLY_ATTR = "readonly";
   private static final String PRESENTATIONML_MASKED_ATTR = "data-masked";
 
   private static final Set<String> VALID_BOOLEAN_VALUES = new HashSet<>(Arrays.asList("true", "false"));
@@ -62,6 +63,14 @@ public class TextField extends FormElement implements RegexElement, LabelableEle
 
     if (getAttribute(MASKED_ATTR) != null) {
       assertAttributeValue(MASKED_ATTR, VALID_BOOLEAN_VALUES);
+    }
+
+    if (getAttribute(DISABLED_ATTR) != null) {
+      assertAttributeValue(DISABLED_ATTR, VALID_BOOLEAN_VALUES);
+    }
+
+    if (getAttribute(READONLY_ATTR) != null) {
+      assertAttributeValue(READONLY_ATTR, VALID_BOOLEAN_VALUES);
     }
 
     assertAttributeNotBlank(NAME_ATTR);
@@ -102,6 +111,8 @@ public class TextField extends FormElement implements RegexElement, LabelableEle
       case PATTERN_ERROR_MESSAGE_ATTR:
       case LABEL:
       case TITLE:
+      case DISABLED_ATTR:
+      case READONLY_ATTR:
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       case ID_ATTR:
@@ -182,6 +193,14 @@ public class TextField extends FormElement implements RegexElement, LabelableEle
 
     if (getAttribute(MAXLENGTH_ATTR) != null) {
       presentationAttrs.put(MAXLENGTH_ATTR, getAttribute(MAXLENGTH_ATTR));
+    }
+
+    if (getAttribute(DISABLED_ATTR) != null) {
+      presentationAttrs.put(DISABLED_ATTR, getAttribute(DISABLED_ATTR));
+    }
+
+    if (getAttribute(READONLY_ATTR) != null) {
+      presentationAttrs.put(READONLY_ATTR, getAttribute(READONLY_ATTR));
     }
 
     if (getChildren() != null && getChildren().size() == 1) {

--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TimePicker.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TimePicker.java
@@ -34,6 +34,8 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
   private static final String STEP_ATTR = "step";
   private static final String STRICT_ATTR = "strict";
   private static final String FORMAT_ATTR = "format";
+  private static final String DISABLED_ATTR = "disabled";
+  private static final String READONLY_ATTR = "readonly";
 
   // PresentationML specific attributes
   private static final String PRESENTATIONML_FORMAT_ATTR = "data-format";
@@ -67,6 +69,8 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
       case MIN_ATTR:
       case MAX_ATTR:
       case STEP_ATTR:
+      case DISABLED_ATTR:
+      case READONLY_ATTR:
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       case DISABLED_TIME_ATTR:
@@ -114,6 +118,13 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
 
     if (getAttribute(STRICT_ATTR) != null) {
       assertAttributeValue(STRICT_ATTR, Arrays.asList("true", "false"));
+    }
+
+    if (getAttribute(DISABLED_ATTR) != null) {
+      assertAttributeValue(DISABLED_ATTR, Arrays.asList("true", "false"));
+    }
+    if (getAttribute(READONLY_ATTR) != null) {
+      assertAttributeValue(READONLY_ATTR, Arrays.asList("true", "false"));
     }
   }
 
@@ -294,6 +305,12 @@ public class TimePicker extends FormElement implements LabelableElement, Tooltip
     }
     if (getAttribute(PRESENTATIONML_DISABLED_TIME_ATTR) != null) {
       presentationAttrs.put(PRESENTATIONML_DISABLED_TIME_ATTR, getAttribute(PRESENTATIONML_DISABLED_TIME_ATTR));
+    }
+    if (getAttribute(DISABLED_ATTR) != null) {
+      presentationAttrs.put(DISABLED_ATTR, getAttribute(DISABLED_ATTR));
+    }
+    if (getAttribute(READONLY_ATTR) != null) {
+      presentationAttrs.put(READONLY_ATTR, getAttribute(READONLY_ATTR));
     }
     return presentationAttrs;
   }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/CheckboxTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/CheckboxTest.java
@@ -368,6 +368,58 @@ public class CheckboxTest extends ElementTest {
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
 
+  @Test
+  public void testCheckboxWithReadyOnlyAndDisabledAttributes() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><checkbox name=\"id1\" value=\"value01\" "
+            + "checked=\"true\" readonly=\"false\" disabled=\"true\">Red</checkbox><button "
+            + "name=\"submit\" type=\"action\">Submit</button></form></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    String presentationML = context.getPresentationML();
+    int startId = presentationML.indexOf("label for=\"");
+    int endId = presentationML.indexOf('"', startId + "label for=\"".length());
+    String id = presentationML.substring(startId + "label for=\"".length(), endId);
+
+    String expectedPresentationML =
+        String.format(
+            "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"form_id\"><div "
+                + "class=\"checkbox-group\"><input type=\"checkbox\" name=\"id1\" checked=\"true\" "
+                + "value=\"value01\" disabled=\"true\" readonly=\"false\" "
+                + "id=\"%s\"/><label "
+                + "for=\"%s\">Red</label></div><button type=\"action\" "
+                + "name=\"submit\">Submit</button></form></div>", id, id);
+
+    assertEquals(expectedPresentationML, context.getPresentationML());
+  }
+
+  @Test
+  public void testCheckboxWithInvalidReadyOnlyAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><checkbox name=\"id1\" value=\"value01\" "
+            + "checked=\"true\" readonly=\"invalid\">Red</checkbox><button "
+            + "name=\"submit\" type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"readonly\" of element \"checkbox\" can only be one of the following values: "
+            + "[true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testCheckboxWithInvalidDisabledAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><checkbox name=\"id1\" value=\"value01\" "
+            + "checked=\"true\" disabled=\"invalid\">Red</checkbox><button "
+            + "name=\"submit\" type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"disabled\" of element \"checkbox\" can only be one of the following values: "
+            + "[true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+
+
   private static Stream<Arguments> messageMlStream() {
     return Stream.of(
         Arguments.of(

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/DatePickerTest.java
@@ -519,5 +519,54 @@ public class DatePickerTest extends ElementTest {
     assertMessageLengthBiItem(items.get(3), input.length());
   }
 
+  @Test
+  public void testDatePickerWithReadyOnlyAndDisabledAttributes() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><date-picker name=\"init\" value=\"2020-08-28\" "
+            + "disabled=\"true\" readonly=\"true\"></date-picker><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    String expectedPresentationML =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"form_id\"><input "
+            + "type=\"date\" name=\"init\" value=\"2020-08-28\" disabled=\"true\" "
+            + "readonly=\"true\"></input><button type=\"action\" "
+            + "name=\"submit\">Submit</button></form></div>";
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    assertEquals(expectedPresentationML, context.getPresentationML());
+  }
+
+  @Test
+  public void testDatePickerWithInvalidReadyOnlyAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><date-picker name=\"init\" value=\"2020-08-28\" "
+            + "readonly=\"invalid\"></date-picker><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"readonly\" of element \"date-picker\" can only be one of the following "
+            + "values: "
+            + "[true, false].");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testDatePickerWithInvalidDisabledAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><date-picker name=\"init\" value=\"2020-08-28\" "
+            + "disabled=\"invalid\"></date-picker><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"disabled\" of element \"date-picker\" can only be one of the following "
+            + "values: "
+            + "[true, false].");
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+
+
 
 }

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/RadioTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/RadioTest.java
@@ -604,6 +604,58 @@ public class RadioTest extends ElementTest {
     assertMessageLengthBiItem(items.get(4), input.length());
   }
 
+  @Test
+  public void testRadioWithReadyOnlyAndDisabledAttributes() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><radio name=\"groupId\" value=\"value01\" "
+            + "checked=\"true\" disabled=\"true\" readonly=\"true\">Red</radio><button "
+            + "name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    String presentationML = context.getPresentationML();
+    String id = getInputId(context.getPresentationML());
+
+    String expectedPresentationML =
+        String.format(
+            "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"form_id\"><div "
+                + "class=\"radio-group\"><input type=\"radio\" name=\"groupId\" checked=\"true\" "
+                + "value=\"value01\" disabled=\"true\" readonly=\"true\" "
+                + "id=\"%s\"/><label "
+                + "for=\"%s\">Red</label></div><button type=\"action\" "
+                + "name=\"submit\">Submit</button></form></div>",
+            id, id);
+
+    assertEquals(expectedPresentationML, context.getPresentationML());
+  }
+
+  @Test
+  public void testRadioWithInvalidReadyOnlyAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><radio name=\"groupId\" value=\"value01\" "
+            + "checked=\"true\" readonly=\"invalid\">Red</radio><button "
+            + "name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"readonly\" of element \"radio\" can only be one of the following values: "
+            + "[true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testRadioWithInvalidDisabledAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><radio name=\"groupId\" value=\"value01\" "
+            + "checked=\"true\" disabled=\"invalid\">Red</radio><button "
+            + "name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"disabled\" of element \"radio\" can only be one of the following values: "
+            + "[true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
   static String getInputId(String presentationML) {
     int startId = presentationML.indexOf("label for=\"");
     int endId = presentationML.indexOf('"', startId + "label for=\"".length());

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/SelectOptionTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/SelectOptionTest.java
@@ -688,6 +688,58 @@ public class SelectOptionTest extends ElementTest {
   }
 
   @Test
+  public void testSelectWithReadyOnlyAndDisabledAttributes() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><select name=\"init\" disabled=\"true\" "
+            + "readonly=\"true\"><option value=\"opt1\">Unselected option 1</option><option "
+            + "value=\"opt2\" selected=\"true\">With selected option</option><option "
+            + "value=\"opt3\">Unselected option 2</option></select><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+
+    String expectedPresentationML =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"form_id\"><select "
+            + "disabled=\"true\" name=\"init\" readonly=\"true\"><option "
+            + "value=\"opt1\">Unselected option 1</option><option selected=\"true\" "
+            + "value=\"opt2\">With selected option</option><option value=\"opt3\">Unselected "
+            + "option 2</option></select><button type=\"action\" "
+            + "name=\"submit\">Submit</button></form></div>";
+
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    assertEquals(expectedPresentationML, context.getPresentationML());
+  }
+
+  @Test
+  public void testSelectWithInvalidReadyOnlyAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><select name=\"init\" readonly=\"invalid\"><option "
+            + "value=\"opt1\">Unselected option 1</option><option "
+            + "value=\"opt2\" selected=\"true\">With selected option</option><option "
+            + "value=\"opt3\">Unselected option 2</option></select><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"readonly\" of element \"select\" can only be one of the following values: "
+            + "[true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testSelectWithInvalidDisabledAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><select name=\"init\" disabled=\"invalid\"><option "
+            + "value=\"opt1\">Unselected option 1</option><option "
+            + "value=\"opt2\" selected=\"true\">With selected option</option><option "
+            + "value=\"opt3\">Unselected option 2</option></select><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"disabled\" of element \"select\" can only be one of the following values: "
+            + "[true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
   public void testBiContextSelect()
       throws InvalidInputException, IOException, ProcessingException {
     MessageMLContext messageMLContext = new MessageMLContext(null);

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextAreaTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextAreaTest.java
@@ -400,6 +400,47 @@ public class TextAreaTest extends ElementTest {
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
   }
 
+  @Test
+  public void testTextAreaWithReadyOnlyAndDisabledAttributes() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><textarea name=\"id1\" disabled=\"true\" "
+            + "readonly=\"true\">With initial value</textarea><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    String expectedPresentationML =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"form_id\"><textarea "
+            + "disabled=\"true\" name=\"id1\" readonly=\"true\">With initial "
+            + "value</textarea><button type=\"action\" "
+            + "name=\"submit\">Submit</button></form></div>";
+    assertEquals(expectedPresentationML, context.getPresentationML());
+  }
+
+  @Test
+  public void testTextAreaWithInvalidReadyOnlyAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><textarea name=\"id1\" readonly=\"invalid\">With initial"
+            + " value</textarea><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"readonly\" of element \"textarea\" can only be one of the following values: "
+            + "[true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testTextAreaWithInvalidDisabledAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><textarea name=\"id1\" disabled=\"invalid\">With initial"
+            + " value</textarea><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"disabled\" of element \"textarea\" can only be one of the following values: "
+            + "[true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
   private static Stream<Arguments> messageMlStream() {
     return Stream.of(
         Arguments.of(

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextFieldTest.java
@@ -782,6 +782,47 @@ public class TextFieldTest extends ElementTest {
     assertMessageLengthBiItem(items.get(3), input.length());
   }
 
+  @Test
+  public void testTextFieldWithReadyOnlyAndDisabledAttributes() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><text-field name=\"init\" disabled=\"true\" "
+            + "readonly=\"true\">With initial value</text-field><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    String expectedPresentationML =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"form_id\"><input "
+            + "type=\"text\" name=\"init\" disabled=\"true\" readonly=\"true\" value=\"With "
+            + "initial value\"/><button type=\"action\" "
+            + "name=\"submit\">Submit</button></form></div>";
+    assertEquals(expectedPresentationML, context.getPresentationML());
+  }
+
+  @Test
+  public void testTextFieldWithInvalidReadyOnlyAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><text-field name=\"init\" readonly=\"invalid\">With "
+            + "initial value</text-field><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"readonly\" of element \"text-field\" can only be one of the following values: "
+            + "[true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testTextFieldWithInvalidDisabledAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><text-field name=\"init\" disabled=\"invalid\">With "
+            + "initial value</text-field><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"disabled\" of element \"text-field\" can only be one of the following values: "
+            + "[true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
 
   private String getLabelId(String presentationML) {
     String textFieldRegex = ".*(\"textfield-(.*?)\").*";

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TimePickerTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TimePickerTest.java
@@ -463,4 +463,57 @@ public class TimePickerTest extends ElementTest {
         0, items.size());
   }
 
+  @Test
+  public void testTextFieldWithReadyOnlyAndDisabledAttributes() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><time-picker name=\"init\" label=\"With default value\" "
+            + "value=\"13:51:06\" disabled=\"true\" readonly=\"true\"/><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+
+    String presentationML = context.getPresentationML();
+    String timePickerRegex = ".*(\"time-picker-(.*?)\").*";
+    Pattern pattern = Pattern.compile(timePickerRegex);
+    Matcher matcher = pattern.matcher(presentationML);
+    String uniqueLabelId = matcher.matches() ? matcher.group(2) : null;
+
+    String expectedPresentationML = String.format(
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"form_id\"><div "
+            + "class=\"time-picker-group\" data-generated=\"true\"><label "
+            + "for=\"time-picker-%s\">With default value</label><input type=\"time\" "
+            + "name=\"init\" value=\"13:51:06\" disabled=\"true\" readonly=\"true\" "
+            + "id=\"time-picker-%s\"/></div><button type=\"action\" "
+            + "name=\"submit\">Submit</button></form></div>", uniqueLabelId, uniqueLabelId);
+    assertEquals(expectedPresentationML, context.getPresentationML());
+  }
+
+  @Test
+  public void testTimePickerWithInvalidReadyOnlyAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><time-picker name=\"init\" label=\"With default value\" "
+            + "value=\"13:51:06\" readonly=\"invalid\"/><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"readonly\" of element \"time-picker\" can only be one of the following "
+            + "values: [true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testTimePickerWithInvalidDisabledAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><time-picker name=\"init\" label=\"With default value\" "
+            + "value=\"13:51:06\" disabled=\"invalid\"/><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage(
+        "Attribute \"disabled\" of element \"time-picker\" can only be one of the following "
+            + "values: "
+            + "[true, false].");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+
+
 }


### PR DESCRIPTION
add support to disabled and readonly attributes for the following components:
checkbox radio date-picker select textarea text-field  time-picker

### :white_check_mark: Checklist 
- [ ] Unit tests and Javadoc
- [ ] Generated PresentationML is valid
> :warning: For this point, please make sure that you have also added a complete example in the 
> `/examples` resources folder. This way the `Mml2Pml2Pml.java` test will ensure that the generated PresentationML is 
> an actual MessageML valid one. 
