### PR TITLE
[AGNT-366][C2-20894] support rows and cols atributes  for textarea

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/TextArea.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/TextArea.java
@@ -28,6 +28,8 @@ public class TextArea extends FormElement implements RegexElement, LabelableElem
 
   private static final String PLACEHOLDER_ATTR = "placeholder";
   private static final String REQUIRED_ATTR = "required";
+  private static final String ROWS = "rows";
+  private static final String COLS = "cols";
   private static final List<String> VALID_VALUES_FOR_REQUIRED_ATTR = Arrays.asList("true", "false");
 
   public TextArea(Element parent, FormatEnum format) {
@@ -44,6 +46,14 @@ public class TextArea extends FormElement implements RegexElement, LabelableElem
 
     if (getAttribute(REQUIRED_ATTR) != null) {
       assertAttributeValue(REQUIRED_ATTR, VALID_VALUES_FOR_REQUIRED_ATTR);
+    }
+
+    if (getAttribute(ROWS) != null) {
+      checkIntegerAttribute(ROWS, 0, "Attribute \"rows\" is not valid, it must be an integer >= 0");
+    }
+
+    if (getAttribute(COLS) != null) {
+      checkIntegerAttribute(COLS, 0, "Attribute \"cols\" is not valid, it must be an integer >= 0");
     }
 
     assertAttributeNotBlank(NAME_ATTR);
@@ -64,6 +74,8 @@ public class TextArea extends FormElement implements RegexElement, LabelableElem
       case PATTERN_ATTR:
       case LABEL:
       case TITLE:
+      case ROWS:
+      case COLS:
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       case PATTERN_ERROR_MESSAGE_ATTR:

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextAreaTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/TextAreaTest.java
@@ -454,4 +454,41 @@ public class TextAreaTest extends ElementTest {
     assertMessageLengthBiItem(items.get(3), input.length());
   }
 
+  @Test
+  public void testTextAreaWithRowsAndColsAttributes() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><textarea name=\"id1\" rows=\"2\" cols=\"3\">With "
+            + "initial value</textarea><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    String expectedPresentationML =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"form_id\"><textarea "
+            + "cols=\"3\" name=\"id1\" rows=\"2\">With initial value</textarea><button "
+            + "type=\"action\" name=\"submit\">Submit</button></form></div>";
+    assertEquals(expectedPresentationML, context.getPresentationML());
+  }
+
+
+  @Test
+  public void testTextAreaWithInvalidRowsAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><textarea name=\"id1\" rows=\"invalid\">With "
+            + "initial value</textarea><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"rows\" is not valid, it must be an integer >= 0");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testTextAreaWithInvalidColsAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><textarea name=\"id1\" cols=\"-1\">With "
+            + "initial value</textarea><button name=\"submit\" "
+            + "type=\"action\">Submit</button></form></messageML>";
+    expectedException.expect(InvalidInputException.class);
+    expectedException.expectMessage("Attribute \"cols\" is not valid, it must be an integer >= 0");
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
 }


### PR DESCRIPTION
### :white_check_mark: Checklist 
- [ ] Unit tests and Javadoc
- [ ] Generated PresentationML is valid
> :warning: For this point, please make sure that you have also added a complete example in the 
> `/examples` resources folder. This way the `Mml2Pml2Pml.java` test will ensure that the generated PresentationML is 
> an actual MessageML valid one. 
