### PR TITLE
[AGNT-366][C2-20898] add icon attribute and support more classes

### DIFF
--- a/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
+++ b/src/main/java/org/symphonyoss/symphony/messageml/elements/Button.java
@@ -45,9 +45,11 @@ public class Button extends Element {
   public static final String ACTION_TYPE = "action";
   public static final String CANCEL_TYPE = "cancel";
   public static final String RESET_TYPE = "reset";
-
+  public static final String MML_ICON_ATTR = "icon";
+  public static final String ICON_ATTR = "data-icon";
   private static final Set<String> VALID_CLASSES = new HashSet<>(Arrays.asList("primary", "secondary", "tertiary", "destructive",
-      "primary-destructive", "secondary-destructive")); // primary-destructive, secondary-destructive are deprecated
+      "primary-destructive", "secondary-destructive", "primary-link", "destructive-link"));
+  // primary-destructive, secondary-destructive are deprecated
   private static final Set<String> VALID_TYPES = new HashSet<>(Arrays.asList(ACTION_TYPE, RESET_TYPE, CANCEL_TYPE));
 
   public Button(Element parent, FormatEnum format) {
@@ -65,6 +67,9 @@ public class Button extends Element {
         setAttribute(item.getNodeName(), getStringAttribute(item));
         break;
       // The button can a have tooltips but is not a tooltipable element because it dont generate the span with tooltip
+      case MML_ICON_ATTR:
+        setAttribute(ICON_ATTR, getStringAttribute(item));
+        break;
       case CLASS_ATTR:
         if (getStringAttribute(item).contains("-destructive")) {
           logger.info("Button class cannot be a destructive one, replacing it accordingly.");

--- a/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
+++ b/src/test/java/org/symphonyoss/symphony/messageml/elements/form/ButtonTest.java
@@ -191,7 +191,16 @@ public class ButtonTest extends ElementTest {
         + "<button name=\"send-answers\" type=\"action\" class=\"primary\">Send Answers</button>\n"
         + "<button name=\"send-answers\" type=\"action\" class=\"secondary\">Send Answers</button>\n"
         + "<button name=\"send-answers\" type=\"action\" class=\"tertiary\">Send Answers</button>\n"
-        + "<button name=\"send-answers\" type=\"action\" class=\"destructive\">Send Answers</button>"
+        + "<button name=\"send-answers\" type=\"action\" class=\"destructive\">Send "
+        + "Answers</button>\n"
+        + "<button name=\"send-answers\" type=\"action\" class=\"primary-destructive\">Send "
+        + "Answers</button>\n"
+        + "<button name=\"send-answers\" type=\"action\" class=\"secondary-destructive\">Send "
+        + "Answers</button>\n"
+        + "<button name=\"send-answers\" type=\"action\" class=\"primary-link\">Send "
+        + "Answers</button>\n"
+        + "<button name=\"send-answers\" type=\"action\" class=\"destructive-link\">Send "
+        + "Answers</button>"
         + "</form></messageML>";
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION); // if no exception thrown all is ok
   }
@@ -388,6 +397,19 @@ public class ButtonTest extends ElementTest {
     expectedException.expect(InvalidInputException.class);
     expectedException.expectMessage("Attributes \"type\" and \"name\" are not allowed on a button inside a UIAction.");
     context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+  }
+
+  @Test
+  public void testButtonWithIconAttribute() throws Exception {
+    String input =
+        "<messageML><form id=\"form_id\"><button name=\"submit\" class=\"primary-link\" "
+            + "icon=\"search\" type=\"action\">Submit</button></form></messageML>";
+    context.parseMessageML(input, null, MessageML.MESSAGEML_VERSION);
+    String expectedPresentationML =
+        "<div data-format=\"PresentationML\" data-version=\"2.0\"><form id=\"form_id\"><button "
+            + "type=\"action\" class=\"primary-link\" data-icon=\"search\" "
+            + "name=\"submit\">Submit</button></form></div>";
+    assertEquals(expectedPresentationML, context.getPresentationML());
   }
 
   @Test


### PR DESCRIPTION
Add support to icon attribute 
add two more supported classes : `primary-link` - `destructive-link`

### :white_check_mark: Checklist 
- [ ] Unit tests and Javadoc
- [ ] Generated PresentationML is valid
> :warning: For this point, please make sure that you have also added a complete example in the 
> `/examples` resources folder. This way the `Mml2Pml2Pml.java` test will ensure that the generated PresentationML is 
> an actual MessageML valid one. 
