### PR TITLE
AGNT-836: Implement pre-execution template allowlisting and auto-escaping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@e9fbacdec3bb3b6036605a3e6f7995d66773a8c6 # v3
       with:
         # 11 runtime needed for Sonar, we still build with 8 as a target
         distribution: 'adopt'

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -11,9 +11,9 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@e9fbacdec3bb3b6036605a3e6f7995d66773a8c6 # v3
         with:
           java-version: '11'
           distribution: 'adopt'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,15 @@ jobs:
       MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@e9fbacdec3bb3b6036605a3e6f7995d66773a8c6 # v3
         with:
           # 11 runtime needed for Sonar, we still build with 8 as a target
           distribution: 'adopt'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,7 +9,7 @@ jobs:
     container:
       image: returntocorp/semgrep
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
       - run: semgrep scan --error --config auto
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.finos.symphony.messageml</groupId>
     <artifactId>messageml-utils</artifactId>
-    <version>1.5.1</version>
+    <version>1.6.0</version>
     <name>MessageML Utils</name>
     <url>https://github.com/finos/messageml-utils</url>
     <description>A set of utilities for parsing, processing and rendering of MessageML messages

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.finos.symphony.messageml</groupId>
     <artifactId>messageml-utils</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <name>MessageML Utils</name>
     <url>https://github.com/finos/messageml-utils</url>
     <description>A set of utilities for parsing, processing and rendering of MessageML messages
@@ -42,7 +42,7 @@
         <logback.version>1.2.9</logback.version>
         <jmh.version>1.33</jmh.version>
         <xmlunit.version>2.8.3</xmlunit.version>
-        <lombok.version>1.18.22</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
         <guava.version>32.1.2-jre</guava.version>
 
         <!-- Maven Plugins -->

--- a/src/main/java/freemarker/core/ASTAccessor.java
+++ b/src/main/java/freemarker/core/ASTAccessor.java
@@ -1,5 +1,12 @@
 package freemarker.core;
 
+/**
+ * Utility class placed in the {@code freemarker.core} package to bypass package-private 
+ * access restrictions in FreeMarker's Abstract Syntax Tree (AST) classes.
+ * <p>
+ * This is necessary for the {@link org.finos.symphony.messageml.messagemlutils.TemplateAllowlistValidator} 
+ * to introspect the parsed template and enforce security policies (preventing SSTI) before execution.
+ */
 public class ASTAccessor {
     public static String getNodeTypeSymbol(TemplateObject obj) {
         return obj.getNodeTypeSymbol();

--- a/src/main/java/freemarker/core/ASTAccessor.java
+++ b/src/main/java/freemarker/core/ASTAccessor.java
@@ -1,0 +1,43 @@
+package freemarker.core;
+
+public class ASTAccessor {
+    public static String getNodeTypeSymbol(TemplateObject obj) {
+        return obj.getNodeTypeSymbol();
+    }
+
+    public static int getParameterCount(TemplateObject obj) {
+        return obj.getParameterCount();
+    }
+
+    public static Object getParameterValue(TemplateObject obj, int index) {
+        return obj.getParameterValue(index);
+    }
+
+    public static ParameterRole getParameterRole(TemplateObject obj, int index) {
+        return obj.getParameterRole(index);
+    }
+
+    public static String getParameterRoleName(TemplateObject obj, int index) {
+        ParameterRole role = obj.getParameterRole(index);
+        return role != null ? role.toString() : "null";
+    }
+
+    public static String getBuiltInKey(TemplateObject obj) {
+        if (obj instanceof BuiltIn) {
+            return ((BuiltIn) obj).key;
+        }
+        return null;
+    }
+
+    public static boolean isSpecialVariable(TemplateObject obj) {
+        return obj instanceof BuiltinVariable;
+    }
+
+    public static boolean isMethodCall(TemplateObject obj) {
+        return obj instanceof MethodCall;
+    }
+
+    public static boolean isNumericalOutput(TemplateObject obj) {
+        return obj instanceof NumericalOutput;
+    }
+}

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/MessageMLParser.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/MessageMLParser.java
@@ -167,6 +167,8 @@ public class MessageMLParser {
     FREEMARKER.setLogTemplateExceptions(false);
     FREEMARKER.setNewBuiltinClassResolver(TemplateClassResolver.ALLOWS_NOTHING_RESOLVER);
     FREEMARKER.setObjectWrapper(new SimpleObjectWrapper(Configuration.VERSION_2_3_30));
+    FREEMARKER.setOutputFormat(freemarker.core.XMLOutputFormat.INSTANCE);
+    FREEMARKER.setAutoEscapingPolicy(Configuration.ENABLE_IF_SUPPORTED_AUTO_ESCAPING_POLICY);
   }
 
   MessageMLParser(IDataProvider dataProvider) {
@@ -322,7 +324,7 @@ public class MessageMLParser {
   /**
    * Expand Freemarker templates.
    */
-  private String expandTemplates(String message, JsonNode entityJson) throws IOException, TemplateException {
+  private String expandTemplates(String message, JsonNode entityJson) throws IOException, TemplateException, InvalidInputException {
     // quick bypass to avoid creating the templating engine if possible
     if (!containsFreemarkerTags(message)) {
       return message;
@@ -336,6 +338,12 @@ public class MessageMLParser {
     // Read MessageMLV2 template
     StringWriter sw = new StringWriter();
     Template template = new Template("messageML", message, FREEMARKER);
+    try {
+      TemplateAllowlistValidator.validate(template);
+    } catch (InvalidInputException e) {
+      this.biContext.updateItemCount(BiFields.FREEMARKER_REJECTED.getValue());
+      throw e;
+    }
 
     // Expand the template
     template.process(data, sw);

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/TemplateAllowlistValidator.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/TemplateAllowlistValidator.java
@@ -1,0 +1,254 @@
+package org.finos.symphony.messageml.messagemlutils;
+
+import freemarker.core.ASTAccessor;
+import freemarker.core.TemplateElement;
+import freemarker.core.TemplateObject;
+import freemarker.template.Template;
+import org.finos.symphony.messageml.messagemlutils.exceptions.InvalidInputException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class TemplateAllowlistValidator {
+
+    private static final Set ALLOWED_ELEMENT_CLASSES = new HashSet();
+    static {
+        ALLOWED_ELEMENT_CLASSES.addAll(Arrays.asList(
+            "TextBlock",
+            "DollarVariable",
+            "MixedContent",
+            "ConditionalBlock",
+            "IfBlock",
+            "IteratorBlock",
+            "ElseOfList",
+            "ListElseContainer",
+            "Sep",
+            "BreakInstruction",
+            "SwitchBlock",
+            "Case",
+            "Assignment",
+            "BlockAssignment",
+            "Comment"
+        ));
+    }
+
+    private static final Set ALLOWED_EXPRESSION_CLASSES = new HashSet();
+    static {
+        ALLOWED_EXPRESSION_CLASSES.addAll(Arrays.asList(
+            "Identifier",
+            "Dot",
+            "DynamicKeyName",
+            "ExistsExpression",
+            "DefaultToExpression",
+            "StringLiteral",
+            "NumberLiteral",
+            "BooleanLiteral",
+            "ListLiteral",
+            "HashLiteral",
+            "AndExpression",
+            "OrExpression",
+            "NotExpression",
+            "AddConcatExpression",
+            "ArithmeticExpression",
+            "ComparisonExpression",
+            "Range",
+            "ParentheticalExpression",
+            "UnaryPlusMinusExpression"
+        ));
+    }
+
+    private static final Set ALLOWED_BUILT_INS = new HashSet();
+    static {
+        ALLOWED_BUILT_INS.addAll(Arrays.asList(
+            "has_content", "size", "length", "index", "keys", "values", "first", "last", "join", "sort_by",
+            "upper_case", "lower_case", "cap_first", "trim", "replace", "split", "contains", "starts_with", "ends_with",
+            "number", "string", "c", "date", "datetime", "default", "if_exists", "round", "abs"
+        ));
+    }
+
+    public static void validate(Template template) throws InvalidInputException {
+        TemplateElement root = template.getRootTreeNode();
+        if (root == null) {
+            return;
+        }
+
+        List inScopeVars = new ArrayList();
+        inScopeVars.add("data");
+        inScopeVars.add("entity");
+        validateNode(root, inScopeVars, root);
+    }
+
+    private static void validateNode(TemplateObject obj, List inScopeVars, TemplateObject parent) throws InvalidInputException {
+        if (obj == null) {
+            return;
+        }
+
+        String className = obj.getClass().getSimpleName();
+
+        if (ASTAccessor.isSpecialVariable(obj)) {
+            throwException(obj, parent, "Special variables like ." + ASTAccessor.getNodeTypeSymbol(obj) + " are not allowed");
+        }
+
+        if (ASTAccessor.isMethodCall(obj)) {
+            throwException(obj, parent, "Method calls are not allowed");
+        }
+
+        if (ASTAccessor.isNumericalOutput(obj)) {
+            throwException(obj, parent, "Numeric interpolation #{...} is not allowed");
+        }
+
+        if (obj instanceof TemplateElement) {
+            parent = obj; // Use the current structural element as the parent for its children/expressions
+            if (!ALLOWED_ELEMENT_CLASSES.contains(className)) {
+                throwException(obj, parent, "Directive or element " + ASTAccessor.getNodeTypeSymbol(obj) + " is not allowed");
+            }
+
+            if (className.equals("IteratorBlock")) {
+                int paramCount = ASTAccessor.getParameterCount(obj);
+                if (paramCount >= 2) {
+                    Object source = ASTAccessor.getParameterValue(obj, 0);
+                    Object targetVar = ASTAccessor.getParameterValue(obj, 1);
+                    if (source instanceof TemplateObject) {
+                        validateNode((TemplateObject) source, inScopeVars, parent);
+                    }
+                    
+                    List childScope = new ArrayList();
+                    childScope.addAll(inScopeVars);
+                    if (targetVar instanceof String && source instanceof TemplateObject) {
+                        if (referencesModel((TemplateObject) source, inScopeVars)) {
+                            childScope.add((String) targetVar);
+                        }
+                    }
+                    
+                    TemplateElement element = (TemplateElement) obj;
+                    for (int i = 0; i < element.getChildCount(); i++) {
+                        validateNode((TemplateObject) element.getChildAt(i), childScope, parent);
+                    }
+                    
+                    for (int i = 2; i < paramCount; i++) {
+                        Object param = ASTAccessor.getParameterValue(obj, i);
+                        validateParam(param, inScopeVars, parent);
+                    }
+                    return;
+                }
+            } else if (className.equals("Assignment") || className.equals("BlockAssignment")) {
+                int paramCount = ASTAccessor.getParameterCount(obj);
+                if (paramCount >= 2) {
+                    Object varName = ASTAccessor.getParameterValue(obj, 0);
+                    Object expr = ASTAccessor.getParameterValue(obj, 1);
+                    if (expr instanceof TemplateObject) {
+                        validateNode((TemplateObject) expr, inScopeVars, parent);
+                    }
+                    
+                    if (varName instanceof String && expr instanceof TemplateObject) {
+                        if (referencesModel((TemplateObject) expr, inScopeVars)) {
+                            inScopeVars.add((String) varName);
+                        }
+                    }
+                    
+                    for (int i = 2; i < paramCount; i++) {
+                        Object param = ASTAccessor.getParameterValue(obj, i);
+                        validateParam(param, inScopeVars, parent);
+                    }
+                    return;
+                }
+            } else if (className.equals("DollarVariable")) {
+                int paramCount = ASTAccessor.getParameterCount(obj);
+                if (paramCount >= 1) {
+                    Object content = ASTAccessor.getParameterValue(obj, 0);
+                    if (content instanceof TemplateObject) {
+                        validateNode((TemplateObject) content, inScopeVars, parent);
+                        if (!referencesModel((TemplateObject) content, inScopeVars)) {
+                            throwException(obj, parent, "Interpolation expression must reference a model variable (e.g. data or entity)");
+                        }
+                    }
+                }
+                return;
+            }
+
+            TemplateElement element = (TemplateElement) obj;
+            for (int i = 0; i < element.getChildCount(); i++) {
+                validateNode((TemplateObject) element.getChildAt(i), inScopeVars, parent);
+            }
+        } else {
+            String biKey = ASTAccessor.getBuiltInKey(obj);
+            if (biKey != null) {
+                if (!ALLOWED_BUILT_INS.contains(biKey)) {
+                    throwException(obj, parent, "Built-in ?" + biKey + " is not allowed");
+                }
+            } else {
+                if (!ALLOWED_EXPRESSION_CLASSES.contains(className)) {
+                    throwException(obj, parent, "Expression type " + className + " is not allowed");
+                }
+            }
+
+            if (className.equals("Identifier")) {
+                String name = ASTAccessor.getNodeTypeSymbol(obj);
+                if (!inScopeVars.contains(name)) {
+                    throwException(obj, parent, "Unknown top-level identifier " + name + " is not allowed");
+                }
+            }
+        }
+
+        int paramCount = ASTAccessor.getParameterCount(obj);
+        for (int i = 0; i < paramCount; i++) {
+            Object param = ASTAccessor.getParameterValue(obj, i);
+            validateParam(param, inScopeVars, parent);
+        }
+    }
+
+    private static void validateParam(Object param, List inScopeVars, TemplateObject parent) throws InvalidInputException {
+        if (param instanceof TemplateObject) {
+            validateNode((TemplateObject) param, inScopeVars, parent);
+        } else if (param instanceof List) {
+            for (Object item : (List) param) {
+                if (item instanceof TemplateObject) {
+                    validateNode((TemplateObject) item, inScopeVars, parent);
+                }
+            }
+        }
+    }
+
+    private static boolean referencesModel(TemplateObject obj, List inScopeVars) {
+        if (obj == null) {
+            return false;
+        }
+
+        String className = obj.getClass().getSimpleName();
+        if (className.equals("Identifier")) {
+            String name = ASTAccessor.getNodeTypeSymbol(obj);
+            return inScopeVars.contains(name);
+        }
+
+        int paramCount = ASTAccessor.getParameterCount(obj);
+        for (int i = 0; i < paramCount; i++) {
+            Object param = ASTAccessor.getParameterValue(obj, i);
+            if (param instanceof TemplateObject) {
+                if (referencesModel((TemplateObject) param, inScopeVars)) {
+                    return true;
+                }
+            } else if (param instanceof List) {
+                for (Object item : (List) param) {
+                    if (item instanceof TemplateObject) {
+                        if (referencesModel((TemplateObject) item, inScopeVars)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void throwException(TemplateObject obj, TemplateObject parent, String reason) throws InvalidInputException {
+        TemplateObject target = obj;
+        if (parent != null && parent.getClass().getSimpleName().equals("Assignment")) {
+            target = parent;
+        }
+        throw new InvalidInputException(String.format("Error parsing Freemarker template: invalid input at line %s, column %s",
+                target.getBeginLine(), target.getBeginColumn()));
+    }
+}

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/TemplateAllowlistValidator.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/TemplateAllowlistValidator.java
@@ -12,6 +12,22 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Validates FreeMarker templates before execution to prevent Server-Side Template Injection (SSTI).
+ * <p>
+ * This validator enforces a strict allowlist of FreeMarker directives, expressions, 
+ * and built-ins. It ensures that the template only performs safe formatting and conditional 
+ * rendering logic, preventing users from executing arbitrary code, reading arbitrary files, 
+ * or accessing unauthorized environment variables on the Agent.
+ * <p>
+ * Key security mechanisms include:
+ * <ul>
+ * <li>Disallowing special variables and method calls.</li>
+ * <li>Blocking numerical interpolation which can be leveraged for SSTI.</li>
+ * <li>Enforcing that all variables reference allowed models (e.g., "data" or "entity").</li>
+ * <li>Restricting loop and assignment scopes to valid models.</li>
+ * </ul>
+ */
 public class TemplateAllowlistValidator {
 
     private static final Set ALLOWED_ELEMENT_CLASSES = new HashSet();

--- a/src/main/java/org/finos/symphony/messageml/messagemlutils/bi/BiFields.java
+++ b/src/main/java/org/finos/symphony/messageml/messagemlutils/bi/BiFields.java
@@ -77,6 +77,7 @@ public enum BiFields {
   MESSAGE_LENGTH("message_length", BiEventType.MESSAGEML_MESSAGE_SENT, "0"),
   ENTITY_JSON_SIZE("entities_json_size", BiEventType.MESSAGEML_MESSAGE_SENT, "0"),
   FREEMARKER("use_freemarker", BiEventType.MESSAGEML_MESSAGE_SENT, "0"),
+  FREEMARKER_REJECTED("freemarker_rejected", BiEventType.MESSAGEML_MESSAGE_SENT, "0"),
   POPUPS("popups", BiEventType.MESSAGEML_MESSAGE_SENT, "0"),
   OPENIM("uiactions_openim", BiEventType.MESSAGEML_MESSAGE_SENT, "0"),
   OPENDIALOG("uiactions_opendialog", BiEventType.MESSAGEML_MESSAGE_SENT, "0"),

--- a/src/test/java/org/finos/symphony/messageml/messagemlutils/TemplateSecurityTest.java
+++ b/src/test/java/org/finos/symphony/messageml/messagemlutils/TemplateSecurityTest.java
@@ -1,0 +1,186 @@
+package org.finos.symphony.messageml.messagemlutils;
+
+import freemarker.core.ASTAccessor;
+import freemarker.core.TemplateClassResolver;
+import freemarker.core.TemplateElement;
+import freemarker.core.TemplateObject;
+import freemarker.template.Configuration;
+import freemarker.template.SimpleObjectWrapper;
+import freemarker.template.Template;
+import freemarker.template.TemplateExceptionHandler;
+import org.finos.symphony.messageml.messagemlutils.bi.BiContext;
+import org.finos.symphony.messageml.messagemlutils.bi.BiFields;
+import org.finos.symphony.messageml.messagemlutils.elements.MessageML;
+import org.finos.symphony.messageml.messagemlutils.exceptions.InvalidInputException;
+import org.finos.symphony.messageml.messagemlutils.util.TestDataProvider;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TemplateSecurityTest {
+
+    @Test
+    public void testCanaryASTAccessor() throws Exception {
+        Configuration cfg = new Configuration(Configuration.VERSION_2_3_30);
+        Template template = new Template("test", new StringReader("${data.field}"), cfg);
+        TemplateElement root = template.getRootTreeNode();
+        assertNotNull(root);
+        
+        String symbol = ASTAccessor.getNodeTypeSymbol(root);
+        assertNotNull(symbol);
+        int paramCount = ASTAccessor.getParameterCount(root);
+        assertTrue(paramCount >= 0);
+    }
+
+    @Test
+    public void testConfigurationRegression() throws Exception {
+        Field freemarkerField = MessageMLParser.class.getDeclaredField("FREEMARKER");
+        freemarkerField.setAccessible(true);
+        Configuration cfg = (Configuration) freemarkerField.get(null);
+
+        assertNotNull(cfg);
+        assertEquals("UTF-8", cfg.getDefaultEncoding());
+        assertEquals(TemplateExceptionHandler.RETHROW_HANDLER, cfg.getTemplateExceptionHandler());
+        assertFalse(cfg.getLogTemplateExceptions());
+        assertEquals(TemplateClassResolver.ALLOWS_NOTHING_RESOLVER, cfg.getNewBuiltinClassResolver());
+        assertTrue(cfg.getObjectWrapper() instanceof SimpleObjectWrapper);
+        assertFalse(cfg.isAPIBuiltinEnabled());
+        
+        assertEquals(cfg.getOutputFormat(), freemarker.core.XMLOutputFormat.INSTANCE);
+        assertEquals(cfg.getAutoEscapingPolicy(), Configuration.ENABLE_IF_SUPPORTED_AUTO_ESCAPING_POLICY);
+    }
+
+    @Test
+    public void testFastPathMarkerConsistency() {
+        String messageWithNoMarkers = "Hello world";
+        assertFalse(containsFreemarkerTags(messageWithNoMarkers));
+
+        assertTrue(containsFreemarkerTags("<#list data as x>"));
+        assertTrue(containsFreemarkerTags("<@myDirective>"));
+        assertTrue(containsFreemarkerTags("${data.name}"));
+        assertTrue(containsFreemarkerTags("#{data.number}"));
+    }
+
+    @Test
+    public void testBiRejectionCounter() throws Exception {
+        MessageMLContext context = new MessageMLContext(new TestDataProvider());
+        String invalidMessage = "<messageML>${7*7}</messageML>";
+        
+        try {
+            context.parseMessageML(invalidMessage, "", MessageML.MESSAGEML_VERSION);
+            fail("Expected parse to fail for pure arithmetic interpolation");
+        } catch (InvalidInputException e) {
+            assertTrue(e.getMessage().contains("Error parsing Freemarker template: invalid input"));
+            BiContext biContext = context.getBiContext();
+            assertNotNull(biContext);
+            long count = biContext.getItems().stream()
+                .filter(item -> item.getName().equals(BiFields.FREEMARKER_REJECTED.getValue()))
+                .count();
+            assertTrue(count >= 0);
+        }
+    }
+
+    @Test
+    public void testNegativeChainsRefused() throws Exception {
+        MessageMLContext context = new MessageMLContext(new TestDataProvider());
+
+        // Chain 1: pure arithmetic
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML>${7*7}</messageML>", "", MessageML.MESSAGEML_VERSION));
+
+        // Chain 2: runtime-assembled eval
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML><#assign k='cl'+'ass'>${('.locale_object['+k+']')?eval}</messageML>", "", MessageML.MESSAGEML_VERSION));
+
+        // ?interpret
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML>${'test'?interpret}</messageML>", "", MessageML.MESSAGEML_VERSION));
+
+        // <#attempt>/<#recover>
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML><#attempt>ok<#recover>fail</#attempt></messageML>", "", MessageML.MESSAGEML_VERSION));
+
+        // Special variable .locale_object
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML>${.locale_object}</messageML>", "", MessageML.MESSAGEML_VERSION));
+
+        // Method call getClass() on model
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML>${data.getClass()}</messageML>", "{}", MessageML.MESSAGEML_VERSION));
+
+        // <#macro>
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML><#macro test>ok</#macro></messageML>", "", MessageML.MESSAGEML_VERSION));
+
+        // <#function>
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML><#function test>ok</#function></messageML>", "", MessageML.MESSAGEML_VERSION));
+
+        // <#include>
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML><#include \"test.ftl\"></messageML>", "", MessageML.MESSAGEML_VERSION));
+
+        // <#import>
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML><#import \"test.ftl\" as t></messageML>", "", MessageML.MESSAGEML_VERSION));
+
+        // <#setting>
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML><#setting locale=\"en_US\"></messageML>", "", MessageML.MESSAGEML_VERSION));
+
+        // <@x/>
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML><@x/></messageML>", "", MessageML.MESSAGEML_VERSION));
+
+        // #{data.amount}
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML>#{data.amount}</messageML>", "{\"amount\": 10}", MessageML.MESSAGEML_VERSION));
+
+        // Unknown top-level identifier
+        assertThrows(InvalidInputException.class, () -> context.parseMessageML("<messageML>${unknown_id}</messageML>", "", MessageML.MESSAGEML_VERSION));
+    }
+
+    @Test
+    public void testChain3HtmlEscaped() throws Exception {
+        MessageMLContext context = new MessageMLContext(new TestDataProvider());
+        String message = "<messageML>${data.formHtml}</messageML>";
+        String data = "{\"formHtml\":\"<form id=\\\"phish\\\"><text-field name=\\\"pwd\\\"/></form>\"}";
+
+        context.parseMessageML(message, data, MessageML.MESSAGEML_VERSION);
+        String presentationML = context.getPresentationML();
+        
+        // Assert that the form elements are fully XML-escaped and not parsed as actual elements
+        assertTrue(presentationML.contains("&lt;form id=&quot;phish&quot;&gt;"));
+        assertFalse(presentationML.contains("<form"));
+        assertFalse(presentationML.contains("<text-field"));
+    }
+
+    @Test
+    public void testChain4AttributeBreakoutEscaped() throws Exception {
+        MessageMLContext context = new MessageMLContext(new TestDataProvider());
+        String message = "<messageML><span class=\"${data.url}\">Link</span></messageML>";
+        String data = "{\"url\":\"x\\\" onerror=\\\"alert(1)\"}";
+
+        context.parseMessageML(message, data, MessageML.MESSAGEML_VERSION);
+        String presentationML = context.getPresentationML();
+
+        // Assert that the quotes are escaped, preventing attribute breakout
+        assertTrue(presentationML.contains("<span class=\"x&quot; onerror=&quot;alert(1)\">Link</span>"));
+    }
+
+    @Test
+    public void testPositiveScenarios() throws Exception {
+        MessageMLContext context = new MessageMLContext(new TestDataProvider());
+        
+        // No markers: byte-identical parsing
+        context.parseMessageML("<messageML>Hello World</messageML>", "", MessageML.MESSAGEML_VERSION);
+        assertTrue(context.getPresentationML().contains("Hello World"));
+
+        // Allowlisted list + interpolation
+        String listMessage = "<messageML><#list data.items as item>Item: ${item}; </#list></messageML>";
+        String listData = "{\"items\":[\"apple\",\"banana\"]}";
+        context.parseMessageML(listMessage, listData, MessageML.MESSAGEML_VERSION);
+        assertTrue(context.getPresentationML().contains("Item: apple; "));
+        assertTrue(context.getPresentationML().contains("Item: banana; "));
+
+        // Allowlisted built-ins (has_content, trim, upper_case, keys, etc.)
+        String builtInMessage = "<messageML><#if data.text?has_content>${data.text?trim?upper_case}</#if></messageML>";
+        String builtInData = "{\"text\":\"  hello  \"}";
+        context.parseMessageML(builtInMessage, builtInData, MessageML.MESSAGEML_VERSION);
+        assertTrue(context.getPresentationML().contains("HELLO"));
+    }
+
+    private boolean containsFreemarkerTags(String message) {
+        return message.contains("<#") || message.contains("<@") || message.contains("${") || message.contains("#{");
+    }
+}


### PR DESCRIPTION
Any user can execute arbitrary FreeMarker expressions on the Agent. This PR introduces strict AST-level allowlisting (directives and expressions), model rooting checks, and XML auto-escaping inside messageml-utils to ensure only safe, model-rooted templates can be parsed and processed.